### PR TITLE
Make the extension releasable, and automate releases from a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+name: Release
+
+# A tag is the single source of truth for a release. Pushing `v0.1.0` tests the
+# extension, packages it, publishes it, and cuts the GitHub release carrying the
+# same `.vsix` and the notes already written in CHANGELOG.md.
+#
+#   npm version minor && git push --follow-tags
+#
+# The registries are optional. Without VSCE_PAT or OVSX_PAT configured the run
+# still produces a GitHub release with an installable `.vsix` attached, so the
+# extension can be handed out before any marketplace account exists.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release, e.g. v0.1.0'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve the version
+        id: version
+        run: |
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          version="${tag#v}"
+          manifest="$(node -p "require('./package.json').version")"
+
+          # A tag that disagrees with the manifest publishes the wrong version
+          # under the right name, which cannot be undone: the Marketplace treats
+          # a version as immutable once it is taken.
+          if [ "$version" != "$manifest" ]; then
+            echo "::error::Tag $tag implies version $version, but package.json says $manifest. Reconcile them and retag."
+            exit 1
+          fi
+
+          # A version with a hyphen (0.2.0-beta.1) is a pre-release.
+          case "$version" in
+            *-*) prerelease=true ;;
+            *)   prerelease=false ;;
+          esac
+
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "prerelease=$prerelease"
+            echo "vsix=ghost-language-$version.vsix"
+          } >> "$GITHUB_OUTPUT"
+
+      - run: npm test
+
+      - name: Extract the release notes
+        run: node scripts/release-notes.js "${{ steps.version.outputs.version }}" > release-notes.md
+
+      - name: Package
+        run: |
+          npm install -g @vscode/vsce
+          vsce package --out "${{ steps.version.outputs.vsix }}" \
+            ${{ steps.version.outputs.prerelease == 'true' && '--pre-release' || '' }}
+
+      - name: Publish to the Visual Studio Marketplace
+        id: marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSIX: ${{ steps.version.outputs.vsix }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::VSCE_PAT is not set, so this release was not published to the Marketplace. The .vsix is still attached to the GitHub release."
+            exit 0
+          fi
+
+          if [ "$PRERELEASE" = 'true' ]; then
+            vsce publish --packagePath "$VSIX" --pre-release
+          else
+            vsce publish --packagePath "$VSIX"
+          fi
+
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to Open VSX
+        id: openvsx
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          VSIX: ${{ steps.version.outputs.vsix }}
+        run: |
+          # Open VSX is what VSCodium, Cursor and the other non-Microsoft builds
+          # install from; they cannot reach the Marketplace.
+          if [ -z "$OVSX_PAT" ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "Open VSX token not set; skipping."
+            exit 0
+          fi
+
+          npm install -g ovsx
+          ovsx publish "$VSIX" -p "$OVSX_PAT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VSIX: ${{ steps.version.outputs.vsix }}
+        run: |
+          gh release create "$TAG" "$VSIX" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            ${{ steps.version.outputs.prerelease == 'true' && '--prerelease' || '' }}
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          MARKETPLACE: ${{ steps.marketplace.outputs.published }}
+          OPENVSX: ${{ steps.openvsx.outputs.published }}
+        run: |
+          {
+            echo "### Released $VERSION"
+            echo
+            echo "| Target | |"
+            echo "| --- | --- |"
+            echo "| GitHub release | published |"
+            echo "| Visual Studio Marketplace | $([ "$MARKETPLACE" = 'true' ] && echo published || echo 'skipped — VSCE_PAT not set') |"
+            echo "| Open VSX | $([ "$OPENVSX" = 'true' ] && echo published || echo 'skipped — OVSX_PAT not set') |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches: [nightly]
+  pull_request:
+
+jobs:
+  test:
+    name: Test on Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      # The extension has no dependencies, so there is nothing to install.
+      - run: npm test
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Packaging on every change catches a manifest that has drifted from the
+      # files it points at — a broken path or a missing contribution fails here
+      # rather than at the moment someone is trying to cut a release.
+      - name: Check the extension packages
+        run: npx --yes @vscode/vsce package --out /tmp/ghost-language.vsix
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vsix
+          path: /tmp/ghost-language.vsix
+          retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         node: ['20', '22']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
 
@@ -27,9 +27,9 @@ jobs:
     name: Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -39,7 +39,7 @@ jobs:
       - name: Check the extension packages
         run: npx --yes @vscode/vsce package --out /tmp/ghost-language.vsix
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: vsix
           path: /tmp/ghost-language.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,7 @@
+.github/**
 .vscode/**
+scripts/**
 test/**
 .gitignore
+.vscodeignore
 **/*.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,4 @@
 .vscode/**
 test/**
 .gitignore
-CHANGELOG.md
 **/*.vsix

--- a/README.md
+++ b/README.md
@@ -105,6 +105,43 @@ Layout:
 When Ghost or Lumen gains a module or method, `src/api/ghost.js` and `src/api/lumen.js` are the files
 to edit; everything else reads from them.
 
+## Releasing
+
+A tag is the whole release. Pushing one runs the tests, packages the extension, publishes it, and
+cuts the GitHub release carrying the same `.vsix` and the notes already written in the changelog:
+
+```bash
+# Add a "## [0.2.0] - YYYY-MM-DD" section to CHANGELOG.md first.
+npm version minor
+git push --follow-tags
+```
+
+`npm version` bumps `package.json`, commits, and tags in one step. The workflow refuses to run if the
+tag and the manifest disagree, because the Marketplace treats a version as immutable once taken —
+publishing the wrong one under the right name cannot be undone.
+
+A version with a hyphen (`0.2.0-beta.1`) is released as a pre-release to both the Marketplace and
+GitHub.
+
+### Tokens
+
+Both are optional. With neither configured a tag still produces a GitHub release with an installable
+`.vsix` attached, which is enough to hand the extension to someone.
+
+| Secret | For | |
+| --- | --- | --- |
+| `VSCE_PAT` | Visual Studio Marketplace | An Azure DevOps token, scoped **Marketplace → Manage** and **all accessible organizations**. Scoping it to one organization produces a token that fails to authenticate. |
+| `OVSX_PAT` | [Open VSX](https://open-vsx.org) | What VSCodium, Cursor and the other non-Microsoft builds install from; they cannot reach the Marketplace. |
+
+### By hand
+
+To build a `.vsix` without tagging anything:
+
+```bash
+npx @vscode/vsce package
+code --install-extension ghost-language-*.vsix
+```
+
 ## Resources
 
 - https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "lumen",
         "game engine"
     ],
-    "private": true,
     "bugs": {
         "url": "https://github.com/ghost-language/vscode/issues"
     },

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// @ts-check
+'use strict';
+
+/**
+ * Lifts one version's section out of CHANGELOG.md, so a GitHub release carries
+ * the notes that were already written rather than a second, drifting copy.
+ *
+ * Usage: node scripts/release-notes.js 0.1.0
+ *
+ * Exits non-zero when the version has no section, which is deliberate: a
+ * release cut without notes is a mistake worth stopping for, not a blank body
+ * worth publishing.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @param {string} changelog  the whole file
+ * @param {string} version    without a leading `v`
+ * @returns {string | undefined}
+ */
+function extract(changelog, version) {
+	const lines = changelog.split('\n');
+	// `## [0.1.0] - 2026-08-22`, and the bare `## [0.1.0]` an unreleased-then-
+	// tagged section can be left as.
+	const heading = new RegExp('^##\\s+\\[' + version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\]');
+	const anyHeading = /^##\s+/;
+
+	const start = lines.findIndex((line) => heading.test(line));
+
+	if (start === -1) {
+		return undefined;
+	}
+
+	let end = lines.length;
+
+	for (let index = start + 1; index < lines.length; index++) {
+		if (anyHeading.test(lines[index])) {
+			end = index;
+			break;
+		}
+	}
+
+	const body = lines.slice(start + 1, end).join('\n').trim();
+
+	return body || undefined;
+}
+
+module.exports = { extract };
+
+if (require.main === module) {
+	const version = (process.argv[2] || '').replace(/^v/, '');
+
+	if (!version) {
+		console.error('usage: node scripts/release-notes.js <version>');
+		process.exit(2);
+	}
+
+	const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
+	const notes = extract(fs.readFileSync(changelogPath, 'utf8'), version);
+
+	if (!notes) {
+		console.error(
+			'No CHANGELOG.md section for ' + version + '. Add a "## [' + version + '] - YYYY-MM-DD" ' +
+			'heading with the release notes under it.'
+		);
+		process.exit(1);
+	}
+
+	process.stdout.write(notes + '\n');
+}

--- a/test/run.js
+++ b/test/run.js
@@ -297,5 +297,38 @@ console.log('\n== grammar and configuration ==');
 }
 
 
+console.log('\n== release tooling ==');
+{
+  const fs = require('fs');
+  const root = path.join(__dirname, '..');
+  const { extract } = require(path.join(root, 'scripts', 'release-notes.js'));
+  const changelog = fs.readFileSync(path.join(root, 'CHANGELOG.md'), 'utf8');
+  const version = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).version;
+
+  // The release workflow fails if the version being tagged has no notes. Catch
+  // that here instead, while there is still something to do about it.
+  const notes = extract(changelog, version);
+  check('CHANGELOG has notes for version ' + version, Boolean(notes));
+  check('notes stop at the next version', Boolean(notes) && !notes.includes('## ['));
+
+  check('unknown version yields nothing', extract(changelog, '9.9.9') === undefined);
+  check('a version is not matched by a prefix of another',
+    extract('## [0.1.0] - 2020-01-01\n- a\n', '0.1') === undefined);
+
+  // A workflow pointing at a file that has moved only fails at release time.
+  for (const workflow of ['test.yml', 'release.yml']) {
+    const full = path.join(root, '.github', 'workflows', workflow);
+    check('workflow exists: ' + workflow, fs.existsSync(full));
+
+    if (!fs.existsSync(full)) continue;
+
+    const body = fs.readFileSync(full, 'utf8');
+    for (const referenced of body.match(/\b(?:scripts|src|test)\/[\w./-]+\.js\b/g) || []) {
+      check(workflow + ' references an existing file: ' + referenced, fs.existsSync(path.join(root, referenced)));
+    }
+  }
+}
+
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Follow-up to #3. That landed the language support; this makes it possible to actually ship it.

## `nightly` cannot currently be released

Two things block it, both fixed in `Make the extension packageable`:

- **`"private": true` in the manifest.** `vsce` refuses to package or publish an extension marked private, so there is no path from the current default branch to an installable `.vsix`.
- **`CHANGELOG.md` was excluded from the package.** The Marketplace renders it as the extension's Changelog tab, so ignoring it would have hidden the release notes from the listing. My mistake in #3.

## Releases

`Automate releases from a tag` makes a tag the single source of truth. Pushing `v0.2.0` runs the tests, packages the extension, publishes it, and cuts the GitHub release carrying that same `.vsix` and the notes already written in `CHANGELOG.md` — so the GitHub release and the extension release are one event, and the notes are not written twice.

```bash
# Add a "## [0.2.0] - YYYY-MM-DD" section to CHANGELOG.md first.
npm version minor
git push --follow-tags
```

The workflow refuses to run when the tag and the manifest disagree. The Marketplace treats a version as immutable once taken, so publishing the wrong version under the right name cannot be undone — the number would have to be burned.

**Both registry tokens are optional.** With neither `VSCE_PAT` nor `OVSX_PAT` configured, a tag still produces a GitHub release with an installable `.vsix` attached, so the extension can be handed out before any Marketplace account exists. The job summary reports which targets published and which were skipped.

| Secret | For |
| --- | --- |
| `VSCE_PAT` | Visual Studio Marketplace. Azure DevOps token, scoped **Marketplace → Manage** and **all accessible organizations** — scoping it to a single organization produces a token that fails to authenticate. |
| `OVSX_PAT` | [Open VSX](https://open-vsx.org), which VSCodium, Cursor and the other non-Microsoft builds install from; they cannot reach the Marketplace. |

## CI

`test.yml` runs the suite on Node 20 and 22 for pushes to `nightly` and all pull requests, plus a packaging job. That second one catches a manifest that has drifted from the files it points at on the pull request, rather than at the moment someone is trying to cut a release. It uploads the `.vsix` as an artifact, so any PR build is installable.

## Verification

`npm test` is at 70 passing, up from 63. The seven new checks cover the release notes extractor and assert that the version in the manifest has changelog notes — the release workflow's one hard failure, now caught while there is still something to do about it. They also verify the workflows only reference files that exist.

I ran the version-guard shell logic directly against matching, pre-release and mismatched tags, and validated both workflows parse as YAML.

**Not verified:** the workflows have never executed, and `vsce` is not installable in my environment (the npm registry returns 403 there), so packaging and publishing are untested end to end. The first tag is where any remaining wrinkle would show up — `workflow_dispatch` is wired in so a run can be retried against an existing tag without retagging.

## Note on the branch

#3 was squash-merged, so this branch was carrying these two commits on top of history that no longer existed under those SHAs. I rebased them onto `nightly` and force-pushed; the diff is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBb69a7BMJXhaeDfAch7EF)_