### PR TITLE
Release on a published release, not on its tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,21 @@
 name: Release
 
-# A tag is the single source of truth for a release. Pushing `v0.1.0` tests the
-# extension, packages it, publishes it, and cuts the GitHub release carrying the
-# same `.vsix` and the notes already written in CHANGELOG.md.
+# Publishing follows a GitHub release. Draft one, publish it, and this tests the
+# extension, packages it, pushes it to the registries, and attaches the `.vsix`
+# to that same release.
 #
-#   npm version minor && git push --follow-tags
-#
-# The registries are optional. Without VSCE_PAT or OVSX_PAT configured the run
-# still produces a GitHub release with an installable `.vsix` attached, so the
-# extension can be handed out before any marketplace account exists.
+# The release is the trigger rather than the tag it creates. Publishing a
+# release creates its tag too, so a workflow listening for tag pushes fires
+# while the release already exists and can only race it — which is exactly how
+# v0.1.0 published to the Marketplace and then failed trying to create a release
+# that was already there.
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to release, e.g. v0.1.0'
+        description: 'Tag of an already-published release to re-run, e.g. v0.1.1'
         required: true
 
 permissions:
@@ -25,60 +25,82 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
-      - name: Resolve the version
-        id: version
+      - name: Resolve the release
+        id: release
         run: |
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
-          version="${tag#v}"
+          version="${TAG#v}"
           manifest="$(node -p "require('./package.json').version")"
 
-          # A tag that disagrees with the manifest publishes the wrong version
-          # under the right name, which cannot be undone: the Marketplace treats
-          # a version as immutable once it is taken.
+          # A release whose tag disagrees with the manifest publishes the wrong
+          # version under the right name, which cannot be undone: the
+          # Marketplace treats a version as immutable once it is taken.
           if [ "$version" != "$manifest" ]; then
-            echo "::error::Tag $tag implies version $version, but package.json says $manifest. Reconcile them and retag."
+            echo "::error::Release $TAG implies version $version, but package.json at that tag says $manifest. Reconcile them and cut the release again."
             exit 1
           fi
 
-          # A version with a hyphen (0.2.0-beta.1) is a pre-release.
-          case "$version" in
-            *-*) prerelease=true ;;
-            *)   prerelease=false ;;
-          esac
+          # Read the release itself rather than the event payload, so that a
+          # manual re-run behaves exactly like the original publish.
+          if ! release="$(gh release view "$TAG" --json isPrerelease,body 2>/dev/null)"; then
+            echo "::error::No published release found for $TAG. This workflow follows a release rather than creating one — publish the release first."
+            exit 1
+          fi
+
+          body="$(jq -r '.body // ""' <<<"$release")"
+
+          # Only offer to fill in notes that were left blank; never overwrite
+          # what a human wrote.
+          if [ -z "${body//[[:space:]]/}" ]; then
+            notes=fill
+          else
+            notes=keep
+          fi
 
           {
-            echo "tag=$tag"
             echo "version=$version"
-            echo "prerelease=$prerelease"
-            echo "vsix=ghost-language-$version.vsix"
+            echo "prerelease=$(jq -r '.isPrerelease' <<<"$release")"
+            echo "notes=$notes"
+            echo "vsix=$RUNNER_TEMP/ghost-language-$version.vsix"
           } >> "$GITHUB_OUTPUT"
 
+      # Runs before anything is published, so a release missing its changelog
+      # section fails while that is still all that is wrong.
       - run: npm test
 
-      - name: Extract the release notes
-        run: node scripts/release-notes.js "${{ steps.version.outputs.version }}" > release-notes.md
-
       - name: Package
+        env:
+          VSIX: ${{ steps.release.outputs.vsix }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
         run: |
           npm install -g @vscode/vsce
-          vsce package --out "${{ steps.version.outputs.vsix }}" \
-            ${{ steps.version.outputs.prerelease == 'true' && '--pre-release' || '' }}
+
+          # Built into the runner's temp directory rather than the workspace:
+          # whatever sits in the workspace at packaging time goes into the
+          # package, which is how a release-notes file shipped inside v0.1.0.
+          if [ "$PRERELEASE" = 'true' ]; then
+            vsce package --out "$VSIX" --pre-release
+          else
+            vsce package --out "$VSIX"
+          fi
 
       - name: Publish to the Visual Studio Marketplace
         id: marketplace
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          VSIX: ${{ steps.version.outputs.vsix }}
-          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          VSIX: ${{ steps.release.outputs.vsix }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
         run: |
           if [ -z "$VSCE_PAT" ]; then
             echo "published=false" >> "$GITHUB_OUTPUT"
@@ -98,7 +120,7 @@ jobs:
         id: openvsx
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
-          VSIX: ${{ steps.version.outputs.vsix }}
+          VSIX: ${{ steps.release.outputs.vsix }}
         run: |
           # Open VSX is what VSCodium, Cursor and the other non-Microsoft builds
           # install from; they cannot reach the Marketplace.
@@ -112,20 +134,29 @@ jobs:
           ovsx publish "$VSIX" -p "$OVSX_PAT"
           echo "published=true" >> "$GITHUB_OUTPUT"
 
-      - name: Create the GitHub release
+      - name: Attach the .vsix to the release
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
-          VSIX: ${{ steps.version.outputs.vsix }}
+          VSIX: ${{ steps.release.outputs.vsix }}
         run: |
-          gh release create "$TAG" "$VSIX" \
-            --title "$TAG" \
-            --notes-file release-notes.md \
-            ${{ steps.version.outputs.prerelease == 'true' && '--prerelease' || '' }}
+          # --clobber so a re-run replaces the asset instead of failing on it.
+          gh release upload "$TAG" "$VSIX" --clobber
+
+      - name: Fill in empty release notes
+        if: steps.release.outputs.notes == 'fill'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          # A courtesy, not a requirement — the extension is already published by
+          # this point, so nothing here should fail the run.
+          if node scripts/release-notes.js "$VERSION" > "$RUNNER_TEMP/release-notes.md"; then
+            gh release edit "$TAG" --notes-file "$RUNNER_TEMP/release-notes.md"
+          else
+            echo "::warning::No CHANGELOG.md section for $VERSION, so the release notes were left as they are."
+          fi
 
       - name: Summary
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.release.outputs.version }}
           MARKETPLACE: ${{ steps.marketplace.outputs.published }}
           OPENVSX: ${{ steps.openvsx.outputs.published }}
         run: |
@@ -134,7 +165,7 @@ jobs:
             echo
             echo "| Target | |"
             echo "| --- | --- |"
-            echo "| GitHub release | published |"
+            echo "| GitHub release \`$TAG\` | .vsix attached |"
             echo "| Visual Studio Marketplace | $([ "$MARKETPLACE" = 'true' ] && echo published || echo 'skipped — VSCE_PAT not set') |"
             echo "| Open VSX | $([ "$OPENVSX" = 'true' ] && echo published || echo 'skipped — OVSX_PAT not set') |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -107,26 +107,38 @@ to edit; everything else reads from them.
 
 ## Releasing
 
-A tag is the whole release. Pushing one runs the tests, packages the extension, publishes it, and
-cuts the GitHub release carrying the same `.vsix` and the notes already written in the changelog:
+Publishing a GitHub release is the whole release. It runs the tests, packages the extension, pushes
+it to the registries, and attaches the `.vsix` to that same release.
 
-```bash
-# Add a "## [0.2.0] - YYYY-MM-DD" section to CHANGELOG.md first.
-npm version minor
-git push --follow-tags
-```
+1. Bump the version and write the notes:
 
-`npm version` bumps `package.json`, commits, and tags in one step. The workflow refuses to run if the
-tag and the manifest disagree, because the Marketplace treats a version as immutable once taken —
+   ```bash
+   # Add a "## [0.2.0] - YYYY-MM-DD" section to CHANGELOG.md.
+   npm version minor
+   git push --follow-tags
+   ```
+
+2. Draft a release on that tag and publish it. Leave the notes blank and the changelog section for
+   the version fills them in.
+
+The release is the trigger rather than the tag, because publishing a release creates its tag too —
+a workflow listening for tag pushes would fire alongside the release and could only race it.
+
+The run stops before publishing anything if the tag and the manifest disagree, or if the changelog
+has no section for the version. The Marketplace treats a version as immutable once taken, so
 publishing the wrong one under the right name cannot be undone.
 
-A version with a hyphen (`0.2.0-beta.1`) is released as a pre-release to both the Marketplace and
-GitHub.
+Marking the release a pre-release on GitHub publishes it to the Marketplace's pre-release channel.
+
+To re-run a release that failed partway — a missing token, a registry timeout — use the workflow's
+**Run workflow** button with the existing tag. Nothing needs to be retagged, and re-running is safe:
+the `.vsix` is replaced rather than added twice, and a version already on the Marketplace fails there
+without affecting the rest.
 
 ### Tokens
 
-Both are optional. With neither configured a tag still produces a GitHub release with an installable
-`.vsix` attached, which is enough to hand the extension to someone.
+Both are optional. With neither configured a release still gets an installable `.vsix` attached,
+which is enough to hand the extension to someone.
 
 | Secret | For | |
 | --- | --- | --- |

--- a/test/run.js
+++ b/test/run.js
@@ -315,6 +315,25 @@ console.log('\n== release tooling ==');
   check('a version is not matched by a prefix of another',
     extract('## [0.1.0] - 2020-01-01\n- a\n', '0.1') === undefined);
 
+  // v0.1.0 shipped with a release-notes.md inside it, because the workflow
+  // wrote that file into the workspace and then packaged the workspace.
+  // Anything a release step generates has to land outside the checkout.
+  const release = fs.readFileSync(path.join(root, '.github', 'workflows', 'release.yml'), 'utf8');
+
+  for (const [what, line] of Object.entries({
+    'the packaged .vsix': /vsix=(\S+)/.exec(release) && /vsix=(\S+)/.exec(release)[1],
+    'the generated release notes': /release-notes\.js[^\n]*?>\s*(\S+)/.exec(release) && /release-notes\.js[^\n]*?>\s*(\S+)/.exec(release)[1]
+  })) {
+    check(what + ' is written outside the workspace', Boolean(line) && line.includes('RUNNER_TEMP'), String(line));
+  }
+
+  // The release is the trigger. Firing on the tag as well would race the
+  // release that created it.
+  check('release.yml follows a published release', /^\s*release:\s*$/m.test(release) && release.includes('types: [published]'));
+  check('release.yml does not also fire on tags', !/tags:/.test(release));
+  check('release.yml attaches to the release rather than creating one',
+    release.includes('gh release upload') && !release.includes('gh release create'));
+
   // A workflow pointing at a file that has moved only fails at release time.
   for (const workflow of ['test.yml', 'release.yml']) {
     const full = path.join(root, '.github', 'workflows', workflow);


### PR DESCRIPTION
Fixes the failure in [run 32557130399](https://github.com/ghost-language/vscode/actions/runs/32557130399/job/96992991306).

## What went wrong

Publishing a GitHub release creates its tag. The workflow listened for tag pushes, so it fired *while the release already existed* and could only race it:

```
Published GhostLanguage.ghost-language v0.1.0.
...
a release with the same tag name already exists: v0.1.0
Error: Process completed with exit code 1
```

The extension published fine — the run went red on the last step, trying to create a release that was already there.

## The fix

`release: [published]` is the trigger, and the `.vsix` is uploaded onto that release rather than a new one being created for it.

A few things follow from the release now being the source of truth:

- **Pre-release follows the flag on the release**, rather than being guessed from a hyphen in the version string. Ticking "set as a pre-release" publishes to the Marketplace's pre-release channel.
- **The release is read back with `gh release view`** rather than taken from the event payload, so a manual re-run behaves exactly like the original publish.
- **Re-running is safe.** `gh release upload --clobber` replaces the asset instead of failing on it, so a release that published but could not finish can be retried from **Run workflow** against the existing tag — no retagging.
- **Notes are only filled in when the release body was left blank.** Anything written by hand is never overwritten.

The version-vs-manifest guard and `npm test` still run before anything is published, so a mismatched tag or a missing changelog section fails while that is still all that is wrong.

## A second bug in that run

v0.1.0 shipped with a `release-notes.md` **inside the extension** — 23 files, where CI had verified 22:

```
├─ release-notes.md [2.95 KB]      ← should not be in a published extension
Packaged: ghost-language-0.1.0.vsix (23 files, 109.45 KB)
```

The workflow wrote that file into the workspace and then packaged the workspace. Everything a release step generates now lands in `$RUNNER_TEMP` instead, and the tests assert it — this class of leak is invisible locally, since `npm test` never packages.

## Verification

`npm test` is at 75, up from 70. The five new checks cover the leak (both generated paths must be outside the checkout) and the trigger itself: follows a published release, does not also fire on tags, uploads rather than creates.

I also exercised the notes/pre-release shell logic directly against a blank body, a whitespace-only body, a real body, and a null body, and re-validated both workflows as YAML.

**Not verified:** the workflow still has not run end to end — it only fires on a real release, and `vsce` is not installable in my environment. The next release is where it gets its first real exercise.

## Note for the next release

**0.1.0 is now taken on the Marketplace and cannot be reused** — versions are immutable once published. The next release needs `0.1.1` or higher, with a matching `CHANGELOG.md` section, or the run will stop at the version guard.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBb69a7BMJXhaeDfAch7EF)_