### PR TITLE
Support Ghost's and Lumen's import-based module system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Rewritten for Ghost's and Lumen's move to an import-based module system: only `console` and the
+  global `type()` function are reachable without an `import` now, so completion, hover, signature
+  help and semantic highlighting all resolve a module, a named import, an `as` alias, or the combined
+  `import name, { a, b } from "scheme:module"` form against what a document actually imports, rather
+  than treating the whole standard library and Lumen's engine as always in scope.
+- `src/api/ghost.js` re-transcribed against the current interpreter: the old `io` module split into
+  `file` and `path`; the old `time` module is gone, folded into `os.sleep` and a new `date` module
+  (date-fns-style, UTC only); `math` gained trigonometry, a full linear-algebra layer, statistics, and
+  arithmetic exposed as callable methods; `List` gained `map`, `filter`, `reduce`, `sort`, `slice`,
+  `concat`, `contains`, `reverse`, `unique`, `each` and a new `shift()`; and `Map` gained `get`, `set`,
+  `has`, `keys`, `values`, `length` and `merge` — it was previously undocumented as having none.
+- `src/api/lumen.js` re-transcribed against the current engine: Lumen no longer extends Ghost's `math`
+  module at all (everything it used to add there now ships natively in `ghost:math`); `Image`,
+  `Spritesheet`, `Animation`, `Source`, `Font`, `Target` and `Quad` are `new`-able classes imported from
+  their owning module (`lumen:image`, `lumen:audio`, `lumen:canvas`, `lumen:font`) rather than built
+  through module-level factory methods like the old `image.newSpritesheet()` and `canvas.newQuad()`.
+- Completion now also completes the `import` statement itself — a module name after `import `, a
+  module name inside an open `"ghost:`/`"lumen:` string, and a module's members and classes inside
+  `{ }` once the `from "scheme:module"` on the same line names it.
+
+### Fixed
+- `List.pop()` removed and returned the *first* element, not the last, in the previous release — the
+  interpreter has since swapped the two: `pop()` now mirrors `push()` from the end of the list, and the
+  old first-element behaviour lives on as the new `shift()`.
+- `print()` no longer exists as a global function. It has fully split into `console.log` (with a
+  trailing newline) and `console.write` (without); the old `console.print` name is gone too.
 
 ## [0.1.0] - 2026-08-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,28 +15,45 @@ compound assignments and `..`.
 
 ### Completion
 
-Completion knows the standard library, and works out what a receiver is before offering its members:
+Ghost's standard library, and Lumen's, are import-based: only `console` and the global `type()`
+function are reachable without one, so completion tracks what a document actually `import`s and offers
+members only for that — `math.` before `import "ghost:math"` offers nothing, because at runtime it
+would be nothing.
 
 ```ghost
-sheet = image.newSpritesheet('characters.png', 16)
-walk  = sheet.newAnimation([4, 5, 6, 7], 0.16)
+import "ghost:math"
+import { Spritesheet, Animation } from "lumen:image"
+
+sheet = new Spritesheet('characters.png', 16)
+walk  = new Animation(sheet, [4, 5, 6, 7], 0.16)
 
 walk.        # offers Animation's methods, not a generic list
+math.        # offers math's members, because this document imported it
 ```
 
-It follows assignments through the document to do this, so a variable holding a value from a library
-call gets the right members even though Ghost is dynamically typed and nothing is annotated. Where a
-receiver genuinely cannot be identified it offers every built-in method there is, each labelled with
-the types that have it, rather than offering nothing.
+Writing the `import` itself is completed too: typing `import ca` offers `canvas` and inserts
+`"lumen:canvas"`; typing inside an open `"ghost:` or `"lumen:` string completes the module name; and
+completing inside `{ }` on a line that already names its module (`import { |} from "lumen:image"`)
+offers that module's members and classes, skipping whichever are already listed.
 
-Also completed: modules and global functions, the names the file itself declares, `this.` members
-inside a class or trait, and — under Lumen — the engine callbacks, inserted as whole function bodies.
+Once imported, a name is completed wherever it is used — `import { sqrt } from "ghost:math"` makes
+`sqrt` itself completable as a callable, and an aliased `import "ghost:math" as m` completes `m`, not
+`math`. Receivers are also resolved by following assignments through the document, including `new`, so
+a variable holding a library value gets the right members even though Ghost is dynamically typed and
+nothing is annotated. Where a receiver genuinely cannot be identified it offers every built-in method
+there is, each labelled with the types that have it, rather than offering nothing.
+
+Also completed: keywords, the names the file itself declares, `this.` members inside a class or trait,
+and — under Lumen — the engine callbacks, inserted as whole function bodies. Callbacks need no import:
+they are plain top-level functions the engine finds by name, not module members.
 
 ### Hover and signature help
 
-Hover documents modules, their methods and properties, global functions, and built-in methods,
-resolved through the same inference completion uses. Signature help shows which argument comes next,
-which matters most for the drawing calls with long optional tails:
+Hover documents modules (under whatever name or alias imported them), their methods and properties,
+imported members used bare, global functions, Lumen classes, and built-in methods, resolved through the
+same import-aware inference completion uses. A module hovered before it is imported, or after the name
+is reassigned to something else, documents nothing — the same thing the interpreter would say. Signature
+help shows which argument comes next, which matters most for the drawing calls with long optional tails:
 
 ```ghost
 sprite.draw(x, y, [rotation, sx, sy, ox, oy])
@@ -49,9 +66,12 @@ in breadcrumbs, and in **Go to Symbol in File**, nested the way they are written
 
 ### Semantic highlighting
 
-Layered over the grammar, this resolves what a regular expression cannot. A name the file assigns to
-is that assignment — writing `image = 3` shadows the module, and the colouring follows. Members are
-checked against the module they are reached through, so a typo stops being highlighted.
+Layered over the grammar, this resolves what a regular expression cannot. A module access is
+highlighted only where the document actually imports it — under its own name, an `as` alias, or through
+the combined import form — the same resolution completion and hover use. A name the file assigns to is
+that assignment, not an import — writing `image = 3` after `import "lumen:image"` shadows the import,
+and the colouring follows. Members are checked against the module they are reached through, so a typo
+stops being highlighted.
 
 ### Editor behaviour
 
@@ -61,17 +81,29 @@ on Enter.
 ## Lumen
 
 A Lumen game is written in Ghost — `.lumen` is a packaged archive, not a source format — so there is
-no second language here. Lumen's modules, object types and callbacks are folded into the Ghost
-surface instead, and can be switched off:
+no second language here. Lumen registers its modules under its own `lumen:` import scheme, the same
+mechanism Ghost's own standard library uses under `ghost:`, so a game imports what it needs exactly
+the way any other Ghost script does:
+
+```ghost
+import "lumen:canvas"
+import "lumen:color"
+import audio, { Source } from "lumen:audio"
+```
+
+Nothing from Lumen is global — not even `canvas` or `window` — so this extension's completion, hover
+and highlighting only ever offer a Lumen name where a document actually imported it. That can be
+switched off entirely, for a workspace that is plain Ghost with no engine in play:
 
 | Setting | Default | |
 | --- | --- | --- |
-| `ghost.lumen.enable` | `true` | Include Lumen's modules, objects and callbacks in completion, hover and highlighting. |
+| `ghost.lumen.enable` | `true` | Include Lumen's modules, classes and callbacks in completion, hover and highlighting. |
 
-Turn it off in a project that is plain Ghost, so that a variable named `window`, `image` or `canvas`
-is not dressed up as something from an engine the project does not use. Lumen's additions to the
-`math` module follow the same switch, matching how the engine registers them onto Ghost's own module
-rather than introducing a second.
+Turning it off removes every Lumen module and class from what can be imported and completed, and every
+Lumen callback from what is recognised in a top-level `function` declaration. Lumen no longer extends
+Ghost's own `math` module the way it once did — everything it used to add there now ships natively in
+`ghost:math` itself, imported the same way whether or not Lumen is in play, so this setting has nothing
+left to do to `math`.
 
 ## Usage
 

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -306,17 +306,363 @@ function enclosingType(symbols, offset) {
 }
 
 /**
+ * What a name bound by an `import` statement actually refers to.
+ *
+ * @typedef {object} ImportBinding
+ * @property {'module'|'member'|'class'} kind
+ * @property {import('./api/types').Source} scheme  `ghost` or `lumen` — the part of `scheme:name` before the colon.
+ * @property {string} module   The module's own name (`math`, `canvas`, ...), regardless of any local alias.
+ * @property {string} [member] The member name, when `kind` is `'member'`.
+ * @property {string} [type]   The class's own name, when `kind` is `'class'`.
+ */
+
+/**
+ * Splits an import path into its scheme and the name after it, mirroring the
+ * interpreter's own `schemePattern` in `evaluator/import.go`: two or more
+ * letters before a `:`, so a Windows drive letter is never mistaken for one.
+ * A path with no such prefix is a `.ghost` file import instead, which this
+ * analyzer cannot resolve — there is no project on disk to read it from.
+ *
+ * @param {string} path
+ * @returns {{ scheme: string, name: string } | undefined}
+ */
+function schemeOf(path) {
+	const match = /^([A-Za-z][A-Za-z0-9+.-]+):(.+)$/.exec(path);
+
+	return match ? { scheme: match[1], name: match[2] } : undefined;
+}
+
+/**
+ * Every name an `import` statement binds in a document, resolved against the
+ * API model.
+ *
+ * Ghost's module system moved behind `import`: only `console` and `type` are
+ * reachable without one (`model.modules`/`model.functions` mark these with
+ * `global: true`), so a receiver like `math` or `canvas` means nothing until
+ * something in the document actually imports it — including through an
+ * alias (`import "ghost:math" as m`), a named pull (`import { pi } from
+ * "ghost:math"`), or the combined form (`import image, { Spritesheet } from
+ * "lumen:image"`). This walks the document once and answers what each bound
+ * name resolves to, so the rest of the analyzer can tell a real module access
+ * from a variable that merely happens to share a module's name.
+ *
+ * A `.ghost` file import (no `scheme:` prefix) binds nothing here — there is
+ * no project on disk to read its exports from — except that its own bound
+ * name is still worth knowing is *taken*, which is what `parseSymbols`-based
+ * shadow tracking already covers separately.
+ *
+ * @param {Api} model
+ * @param {string} text
+ * @returns {Map<string, ImportBinding>}
+ */
+function resolveImports(model, text) {
+	const stripped = strip(text);
+	/** @type {Map<string, ImportBinding>} */
+	const bindings = new Map();
+	const importKeyword = /\bimport\b/g;
+	let match;
+
+	while ((match = importKeyword.exec(stripped)) !== null) {
+		parseImportAt(model, text, stripped, importKeyword.lastIndex, bindings);
+	}
+
+	return bindings;
+}
+
+/**
+ * Parses one `import` statement starting just past the keyword, in the style
+ * of `parser/import.go`: a bare string (optionally `as`-aliased), or a
+ * `from`-form whose name list may be braced, unbraced, wildcard, or the
+ * combined `name, { ... }` shape. Best-effort — a statement this cannot make
+ * sense of is simply left unbound, the same way an unresolved receiver
+ * elsewhere in this file falls back to "unknown" rather than raising.
+ *
+ * @param {Api} model
+ * @param {string} text      the original document, for pulling real string contents
+ * @param {string} stripped  comments and string bodies blanked, offsets preserved
+ * @param {number} start     offset just past the `import` keyword
+ * @param {Map<string, ImportBinding>} bindings
+ */
+function parseImportAt(model, text, stripped, start, bindings) {
+	const len = stripped.length;
+	let i = start;
+
+	const skipSpace = () => { while (i < len && /\s/.test(stripped[i])) i++; };
+	const at = (word) => stripped.startsWith(word, i) && !/\w/.test(stripped[i + word.length] || '');
+	const readIdent = () => {
+		const found = /^[A-Za-z_]\w*/.exec(stripped.slice(i));
+
+		if (!found) {
+			return undefined;
+		}
+
+		i += found[0].length;
+
+		return found[0];
+	};
+	const readString = () => {
+		const quote = stripped[i];
+		let j = i + 1;
+
+		// The interior is blanked to spaces by `strip`, so the next occurrence
+		// of the same quote character is always the real closing quote.
+		while (j < len && stripped[j] !== quote) {
+			j++;
+		}
+
+		const raw = text.slice(i + 1, j);
+
+		i = j + 1;
+
+		return raw;
+	};
+
+	skipSpace();
+
+	if (stripped[i] === '"' || stripped[i] === "'") {
+		// Bare form: import "path" [as alias]
+		const path = readString();
+
+		skipSpace();
+
+		let alias;
+
+		if (at('as')) {
+			i += 2;
+			skipSpace();
+			alias = readIdent();
+		}
+
+		bindWholeModule(model, bindings, path, alias);
+
+		return;
+	}
+
+	// From-form: [name ,] ( { list } | list | * ) from "path"
+	let combinedAlias;
+	const beforeName = i;
+	const firstIdent = readIdent();
+
+	if (firstIdent) {
+		skipSpace();
+
+		if (stripped[i] === ',') {
+			let k = i + 1;
+
+			while (k < len && /\s/.test(stripped[k])) {
+				k++;
+			}
+
+			if (stripped[k] === '{') {
+				combinedAlias = firstIdent;
+				i = k;
+			} else {
+				i = beforeName;
+			}
+		} else {
+			i = beforeName;
+		}
+	} else {
+		i = beforeName;
+	}
+
+	/** @type {{ name: string, alias: string }[]} */
+	const names = [];
+	let everything = false;
+	const braced = stripped[i] === '{';
+
+	if (braced) {
+		i++;
+	}
+
+	skipSpace();
+
+	if (stripped[i] === '*') {
+		everything = true;
+		i++;
+		skipSpace();
+
+		// A braced wildcard (`{ * }`, from the combined form) still has its
+		// closing brace to consume before the `from` check below; an unbraced
+		// `import * from "..."` has nothing more to skip here.
+		if (braced && stripped[i] === '}') {
+			i++;
+			skipSpace();
+		}
+	}
+
+	while (!everything) {
+		if (braced && stripped[i] === '}') {
+			i++;
+			break;
+		}
+
+		if (!braced && at('from')) {
+			break;
+		}
+
+		const name = readIdent();
+
+		if (!name) {
+			return;
+		}
+
+		let alias = name;
+
+		skipSpace();
+
+		if (at('as')) {
+			i += 2;
+			skipSpace();
+			alias = readIdent() || alias;
+			skipSpace();
+		}
+
+		names.push({ name, alias });
+
+		if (stripped[i] === ',') {
+			i++;
+			skipSpace();
+			continue;
+		}
+
+		// No comma: the list is done. A braced list still needs its closing `}`
+		// consumed before the `from` check below, the same way the top-of-loop
+		// check consumes it for an empty or trailing-comma list.
+		if (braced) {
+			skipSpace();
+
+			if (stripped[i] === '}') {
+				i++;
+			}
+		}
+
+		break;
+	}
+
+	skipSpace();
+
+	if (!at('from')) {
+		return;
+	}
+
+	i += 4;
+	skipSpace();
+
+	if (stripped[i] !== '"' && stripped[i] !== "'") {
+		return;
+	}
+
+	const path = readString();
+
+	if (combinedAlias) {
+		bindWholeModule(model, bindings, path, combinedAlias);
+	}
+
+	bindNamedMembers(model, bindings, path, names, everything);
+}
+
+/**
+ * @param {Api} model
+ * @param {Map<string, ImportBinding>} bindings
+ * @param {string} path
+ * @param {string} [alias]
+ */
+function bindWholeModule(model, bindings, path, alias) {
+	const scheme = schemeOf(path);
+
+	if (!scheme || !model.moduleByName.has(scheme.name)) {
+		return;
+	}
+
+	const name = alias || scheme.name;
+
+	bindings.set(name, {
+		kind: 'module',
+		scheme: /** @type {import('./api/types').Source} */ (scheme.scheme),
+		module: scheme.name
+	});
+}
+
+/**
+ * @param {Api} model
+ * @param {Map<string, ImportBinding>} bindings
+ * @param {string} path
+ * @param {{ name: string, alias: string }[]} names
+ * @param {boolean} everything
+ */
+function bindNamedMembers(model, bindings, path, names, everything) {
+	const scheme = schemeOf(path);
+
+	if (!scheme) {
+		return;
+	}
+
+	const schemeName = /** @type {import('./api/types').Source} */ (scheme.scheme);
+	const module = model.moduleByName.get(scheme.name);
+
+	if (everything) {
+		if (module) {
+			for (const member of module.members) {
+				bindings.set(member.name, { kind: 'member', scheme: schemeName, module: scheme.name, member: member.name });
+			}
+		}
+
+		for (const type of api.classesOf(model, schemeName, scheme.name)) {
+			bindings.set(type.name, { kind: 'class', scheme: schemeName, module: scheme.name, type: type.name });
+		}
+
+		return;
+	}
+
+	for (const { name, alias } of names) {
+		const cls = api.findClass(model, schemeName, scheme.name, name);
+
+		if (cls) {
+			bindings.set(alias, { kind: 'class', scheme: schemeName, module: scheme.name, type: cls.name });
+			continue;
+		}
+
+		if (module && module.members.some((member) => member.name === name)) {
+			bindings.set(alias, { kind: 'member', scheme: schemeName, module: scheme.name, member: name });
+		}
+	}
+}
+
+/**
+ * The real module name a receiver refers to — `console` needs no import;
+ * anything else has to be that exact bound name, aliased or not.
+ *
+ * @param {Api} model
+ * @param {string} receiver
+ * @param {Map<string, ImportBinding>} imports
+ * @returns {string | undefined}
+ */
+function resolveModuleName(model, receiver, imports) {
+	const direct = model.moduleByName.get(receiver);
+
+	if (direct && direct.global) {
+		return receiver;
+	}
+
+	const binding = imports.get(receiver);
+
+	return binding && binding.kind === 'module' ? binding.module : undefined;
+}
+
+/**
  * Works out which API type each variable in a document holds.
  *
  * Ghost is dynamically typed, so this is a best effort and deliberately a
  * conservative one: it only records a variable whose value comes from something
- * the API model describes. `sheet = image.newSpritesheet(...)` is recorded
- * because `newSpritesheet` declares what it returns; `x = 3 + y` is not
- * recorded at all, which is better than recording it wrongly.
+ * the API model describes. `today = date.now()` is recorded because `now`
+ * declares what it returns, and `sheet = new Spritesheet(...)` is recorded
+ * directly from the class being constructed; `x = 3 + y` is not recorded at
+ * all, which is better than recording it wrongly.
  *
  * Assignments are resolved repeatedly until nothing new is learned, so a chain
- * like `sheet = image.newSpritesheet(...)` then `walk = sheet.newAnimation(...)`
- * resolves both.
+ * like `sheet = new Spritesheet(...)` then `frame = sheet.getQuad(0)` resolves
+ * both.
  *
  * @param {Api} model
  * @param {string} text
@@ -324,6 +670,7 @@ function enclosingType(symbols, offset) {
  */
 function inferTypes(model, text) {
 	const stripped = strip(text);
+	const imports = resolveImports(model, text);
 	/** @type {Map<string, string>} */
 	const types = new Map();
 
@@ -336,6 +683,29 @@ function inferTypes(model, text) {
 
 	while ((match = memberAssign.exec(stripped)) !== null) {
 		pending.push({ target: match[1], receiver: match[2], member: match[3] });
+	}
+
+	// `name = new Type(...)` — direct, since a class is bound to its own name
+	// (or its import alias) rather than something that has to be looked up.
+	const newAssign = /\b([A-Za-z_]\w*)[ \t]*=[ \t]*new[ \t]+([A-Za-z_]\w*)\s*\(/g;
+
+	while ((match = newAssign.exec(stripped)) !== null) {
+		const [, target, typeName] = match;
+
+		if (types.has(target)) {
+			continue;
+		}
+
+		if (model.typeByName.has(typeName)) {
+			types.set(target, typeName);
+			continue;
+		}
+
+		const binding = imports.get(typeName);
+
+		if (binding && binding.kind === 'class') {
+			types.set(target, /** @type {string} */ (binding.type));
+		}
 	}
 
 	// Literals, which need no resolving.
@@ -360,7 +730,7 @@ function inferTypes(model, text) {
 				continue;
 			}
 
-			const returns = returnTypeOf(model, receiver, member, types);
+			const returns = returnTypeOf(model, receiver, member, types, imports);
 
 			if (returns) {
 				types.set(target, returns);
@@ -383,10 +753,12 @@ function inferTypes(model, text) {
  * @param {string} receiver
  * @param {string} member
  * @param {Map<string, string>} known
+ * @param {Map<string, ImportBinding>} imports
  * @returns {string | undefined}
  */
-function returnTypeOf(model, receiver, member, known) {
-	const onModule = api.findModuleMember(model, receiver, member);
+function returnTypeOf(model, receiver, member, known, imports) {
+	const moduleName = resolveModuleName(model, receiver, imports);
+	const onModule = moduleName && api.findModuleMember(model, moduleName, member);
 
 	if (onModule) {
 		return onModule.member.returns;
@@ -486,22 +858,35 @@ function receiverChain(strippedLine, dotIndex) {
 /**
  * Resolves what a receiver chain refers to.
  *
+ * The head of the chain only counts as a module when it is actually reachable
+ * that way — `console` needs no import, but `canvas`, `math` and everything
+ * else does, whether reached under its own name, an `as` alias, or the
+ * combined import form. A bare built-in type name (`String`, `List`, ...)
+ * still resolves on its own, since those need no import either; a Lumen
+ * class does, the same as a module.
+ *
  * @param {Api} model
  * @param {string[]} chain
  * @param {Map<string, string>} known
+ * @param {Map<string, ImportBinding>} imports
  * @returns {{ kind: 'module', name: string } | { kind: 'type', name: string } | undefined}
  */
-function resolveChain(model, chain, known) {
+function resolveChain(model, chain, known, imports) {
 	const [head, ...rest] = chain;
 
 	/** @type {{ kind: 'module'|'type', name: string } | undefined} */
 	let current;
 
-	if (model.moduleByName.has(head)) {
-		current = { kind: 'module', name: head };
+	const moduleName = resolveModuleName(model, head, imports);
+	const importedClass = imports.get(head);
+
+	if (moduleName) {
+		current = { kind: 'module', name: moduleName };
 	} else if (known.has(head)) {
 		current = { kind: 'type', name: /** @type {string} */ (known.get(head)) };
-	} else if (model.typeByName.has(head)) {
+	} else if (importedClass && importedClass.kind === 'class') {
+		current = { kind: 'type', name: /** @type {string} */ (importedClass.type) };
+	} else if (model.typeByName.has(head) && !model.typeByName.get(head).module) {
 		current = { kind: 'type', name: head };
 	} else {
 		return undefined;
@@ -537,5 +922,7 @@ module.exports = {
 	inferTypes,
 	receiverChain,
 	resolveChain,
+	resolveImports,
+	resolveModuleName,
 	RESERVED_BEFORE_PAREN
 };

--- a/src/api/ghost.js
+++ b/src/api/ghost.js
@@ -2,14 +2,23 @@
 'use strict';
 
 /**
- * The Ghost language surface: keywords, the globals the interpreter registers
- * before a program runs, its standard library modules, and the methods that
- * live on built-in values.
+ * The Ghost language surface: keywords, the two names the interpreter still
+ * registers as reachable without an import, the standard library modules
+ * (each requiring `import ... from "ghost:name"`), and the methods that live
+ * on built-in values.
  *
  * Everything here is transcribed from the interpreter itself — `token.go` and
- * `scanner/scanner.go` for the keywords, `library/library.go` for what is
- * registered, and the `Method` switch on each type in `object/` for the rest —
- * so that the editor never offers a name the runtime does not have.
+ * `scanner/scanner.go` for the keywords, `library/library.go` and
+ * `library/modules/*.go` for what is registered and under which scheme, and
+ * the `Method` switch on each type in `object/` for the rest — so that the
+ * editor never offers a name the runtime does not have.
+ *
+ * Ghost moved to an import-based module system: only `console` and `type`
+ * are reachable without an `import` at all (`library/library.go`'s
+ * `globalModules`/`globalFunctions`). Every other module — `math`, `date`,
+ * `file`, `path`, `os`, `random`, `json`, `http`, `ghost` itself — has to be
+ * pulled in first, the same way Lumen's modules do under its own `lumen:`
+ * scheme (see `lumen.js`).
  */
 
 /** @typedef {import('./types').Member} Member */
@@ -21,8 +30,8 @@
  * Reserved words, from the `keywords` map in `scanner/scanner.go`.
  *
  * `print` is deliberately absent: the token package defines a PRINT type, but
- * the scanner never produces one. `print` reaches programs as a registered
- * library function instead, so it is a global, not a keyword.
+ * the scanner never produces one, and there is no global `print()` either —
+ * `console.log`/`console.write` are what a program actually calls.
  */
 const KEYWORDS = [
 	'and', 'as', 'break', 'case', 'class', 'continue', 'default', 'else',
@@ -37,17 +46,12 @@ const DECLARATION_KEYWORDS = ['class', 'function', 'trait', 'import', 'use'];
 /** @type {GlobalFunction[]} */
 const FUNCTIONS = [
 	{
-		name: 'print',
-		source: 'ghost',
-		signature: 'print(value, ...)',
-		doc: 'Writes each argument separated by a space, followed by a newline. Called with no arguments it writes just the newline.'
-	},
-	{
 		name: 'type',
 		source: 'ghost',
+		global: true,
 		signature: 'type(value)',
 		returns: 'String',
-		doc: 'Returns the name of a value\'s type in lowercase — `"string"`, `"number"`, `"boolean"`, `"list"`, `"map"`, `"null"`, `"function"`, `"class"`, `"instance"`.'
+		doc: 'Returns the name of a value\'s type in lowercase — `"string"`, `"number"`, `"boolean"`, `"list"`, `"map"`, `"null"`, `"function"`, `"class"`, `"instance"`, `"date"`, `"trait"`. Reachable with no import, like `console`.'
 	}
 ];
 
@@ -56,16 +60,79 @@ const MODULES = [
 	{
 		name: 'console',
 		source: 'ghost',
-		doc: 'Reading from and writing to the terminal.',
+		global: true,
+		doc: 'Reading from and writing to the terminal. The one module reachable with no `import` at all, alongside the global `type()` function.',
 		members: [
-			{ name: 'log', kind: 'method', signature: 'console.log(value, ...)', doc: 'Writes to standard output with a trailing newline.' },
-			{ name: 'print', kind: 'method', signature: 'console.print(value, ...)', doc: 'Writes to standard output without a trailing newline.' },
-			{ name: 'info', kind: 'method', signature: 'console.info(value, ...)', doc: 'Writes an informational message.' },
-			{ name: 'warn', kind: 'method', signature: 'console.warn(value, ...)', doc: 'Writes a warning message.' },
-			{ name: 'error', kind: 'method', signature: 'console.error(value, ...)', doc: 'Writes an error message.' },
-			{ name: 'read', kind: 'method', signature: 'console.read([prompt])', returns: 'String', doc: 'Reads a line from standard input and returns it as a string.' },
-			{ name: 'clear', kind: 'method', signature: 'console.clear()', doc: 'Clears the terminal.' },
-			{ name: 'newLine', kind: 'method', signature: 'console.newLine()', doc: 'Writes a single newline.' }
+			{ name: 'log', kind: 'method', signature: 'console.log(value, ...)', doc: 'Writes each argument separated by a space, followed by a newline. Called with no arguments it writes just the newline.' },
+			{ name: 'write', kind: 'method', signature: 'console.write(value, ...)', doc: 'Writes without a trailing newline — the `write()`/`writeln()` split Symfony\'s Console component draws. This is `console.log` without the newline, not a synonym for it.' },
+			{ name: 'newLine', kind: 'method', signature: 'console.newLine()', doc: 'Writes a single newline.' },
+			{ name: 'info', kind: 'method', signature: 'console.info(value, ...)', doc: 'Writes an informational line, prefixed `info:` when the output stream supports colour.' },
+			{ name: 'warn', kind: 'method', signature: 'console.warn(value, ...)', doc: 'Writes a warning line, prefixed `warning:`.' },
+			{ name: 'error', kind: 'method', signature: 'console.error(value, ...)', doc: 'Writes an error line, prefixed `error:`.' },
+			{ name: 'read', kind: 'method', signature: 'console.read([prompt])', returns: 'String', doc: 'Reads a line from standard input, printing `prompt` first if given, and returns it as a string — or **null** at end of file.' },
+			{ name: 'clear', kind: 'method', signature: 'console.clear()', doc: 'Clears the terminal.' }
+		]
+	},
+	{
+		name: 'date',
+		source: 'ghost',
+		doc: 'Dates, modelled on date-fns: every function takes a `Date` and returns a new one — nothing mutates. **Every `Date` is UTC only; there is no time zone support.**\n\nA `Date` compares directly with `<`, `>`, `<=`, `>=`, `==` — there is no separate `isBefore()`/`isAfter()` — and supports no arithmetic operators of its own; use this module\'s functions instead.',
+		members: [
+			{ name: 'now', kind: 'method', signature: 'date.now()', returns: 'Date', doc: 'The current instant.' },
+			{ name: 'today', kind: 'method', signature: 'date.today()', returns: 'Date', doc: 'Today at 00:00:00 UTC.' },
+			{ name: 'of', kind: 'method', signature: 'date.of(year, month, day, [hour, minute, second])', returns: 'Date', doc: 'Builds a date from calendar components. **`month` is 1–12**, not 0-based. Errors — rather than rolling over — if the month, hour, minute or second is out of range, or the day does not exist in that month (Feb 30).' },
+			{ name: 'parseISO', kind: 'method', signature: 'date.parseISO(text)', returns: 'Date', doc: 'Parses `2024-01-15` or a full RFC3339 timestamp (`2024-01-15T09:30:00Z`).' },
+			{ name: 'fromUnix', kind: 'method', signature: 'date.fromUnix(seconds)', returns: 'Date', doc: 'From a Unix timestamp.' },
+			{ name: 'toUnix', kind: 'method', signature: 'date.toUnix(d)', returns: 'Number', doc: 'Seconds since the epoch.' },
+			{ name: 'toUnixNano', kind: 'method', signature: 'date.toUnixNano(d)', returns: 'Number', doc: 'Nanoseconds since the epoch.' },
+			{ name: 'format', kind: 'method', signature: 'date.format(d, pattern)', returns: 'String', doc: 'Formats with date-fns-style pattern letters (not Go\'s reference layout): `yyyy`/`yy`, `MMMM`/`MMM`/`MM`/`M`, `dd`/`d`, `EEEE`/`EEE` (weekday name), `HH`/`H` (24h), `hh`/`h` (12h), `mm`, `ss`, `a` (AM/PM). Anything else is copied literally.' },
+			{ name: 'addDays', kind: 'method', signature: 'date.addDays(d, n)', returns: 'Date', doc: 'Paired with `subDays` rather than taking a negative count.' },
+			{ name: 'subDays', kind: 'method', signature: 'date.subDays(d, n)', returns: 'Date' },
+			{ name: 'addWeeks', kind: 'method', signature: 'date.addWeeks(d, n)', returns: 'Date' },
+			{ name: 'subWeeks', kind: 'method', signature: 'date.subWeeks(d, n)', returns: 'Date' },
+			{ name: 'addMonths', kind: 'method', signature: 'date.addMonths(d, n)', returns: 'Date', doc: 'Clamps to the last valid day of the target month rather than rolling over — Jan 31 + 1 month is Feb 28 (or 29), not Mar 2/3.' },
+			{ name: 'subMonths', kind: 'method', signature: 'date.subMonths(d, n)', returns: 'Date' },
+			{ name: 'addYears', kind: 'method', signature: 'date.addYears(d, n)', returns: 'Date', doc: 'Clamps the same way `addMonths` does, for Feb 29 on a non-leap target year.' },
+			{ name: 'subYears', kind: 'method', signature: 'date.subYears(d, n)', returns: 'Date' },
+			{ name: 'addHours', kind: 'method', signature: 'date.addHours(d, n)', returns: 'Date' },
+			{ name: 'addMinutes', kind: 'method', signature: 'date.addMinutes(d, n)', returns: 'Date' },
+			{ name: 'addSeconds', kind: 'method', signature: 'date.addSeconds(d, n)', returns: 'Date' },
+			{ name: 'isSameDay', kind: 'method', signature: 'date.isSameDay(a, b)', returns: 'Boolean', doc: 'Whether two dates fall on the same calendar year, month and day.' },
+			{ name: 'isWeekend', kind: 'method', signature: 'date.isWeekend(d)', returns: 'Boolean', doc: 'Whether `d` falls on a Saturday or Sunday.' },
+			{ name: 'isLeapYear', kind: 'method', signature: 'date.isLeapYear(d)', returns: 'Boolean' },
+			{ name: 'differenceInDays', kind: 'method', signature: 'date.differenceInDays(a, b)', returns: 'Number', doc: 'Truncated toward zero; `differenceInDays(a, b) == -differenceInDays(b, a)`.' },
+			{ name: 'differenceInHours', kind: 'method', signature: 'date.differenceInHours(a, b)', returns: 'Number' },
+			{ name: 'differenceInMinutes', kind: 'method', signature: 'date.differenceInMinutes(a, b)', returns: 'Number' },
+			{ name: 'differenceInSeconds', kind: 'method', signature: 'date.differenceInSeconds(a, b)', returns: 'Number' },
+			{ name: 'startOfDay', kind: 'method', signature: 'date.startOfDay(d)', returns: 'Date' },
+			{ name: 'endOfDay', kind: 'method', signature: 'date.endOfDay(d)', returns: 'Date', doc: '23:59:59.999999999 that day.' },
+			{ name: 'startOfMonth', kind: 'method', signature: 'date.startOfMonth(d)', returns: 'Date' },
+			{ name: 'endOfMonth', kind: 'method', signature: 'date.endOfMonth(d)', returns: 'Date' },
+			{ name: 'year', kind: 'method', signature: 'date.year(d)', returns: 'Number' },
+			{ name: 'month', kind: 'method', signature: 'date.month(d)', returns: 'Number', doc: '1–12.' },
+			{ name: 'day', kind: 'method', signature: 'date.day(d)', returns: 'Number' },
+			{ name: 'hour', kind: 'method', signature: 'date.hour(d)', returns: 'Number' },
+			{ name: 'minute', kind: 'method', signature: 'date.minute(d)', returns: 'Number' },
+			{ name: 'second', kind: 'method', signature: 'date.second(d)', returns: 'Number' },
+			{ name: 'weekday', kind: 'method', signature: 'date.weekday(d)', returns: 'Number', doc: '0 (Sunday) through 6 (Saturday).' }
+		]
+	},
+	{
+		name: 'file',
+		source: 'ghost',
+		doc: 'Reading and writing files, resolved relative to the running source file\'s own directory. Pure string manipulation on a path — without touching the filesystem — is `path`, not this.\n\nUnder Lumen this is the right module for a game\'s own shipped data and the wrong one for saves — see Lumen\'s `filesystem`.',
+		members: [
+			{ name: 'read', kind: 'method', signature: 'file.read(path)', returns: 'String', doc: 'Reads a file and returns its contents.' },
+			{ name: 'write', kind: 'method', signature: 'file.write(path, contents)', doc: 'Replaces the contents of a file that must already exist, keeping its permissions. Errors, with help, if it does not — use `append` to create one.' },
+			{ name: 'append', kind: 'method', signature: 'file.append(path, contents)', doc: 'Appends a line to a file, creating it if it does not exist.' },
+			{ name: 'exists', kind: 'method', signature: 'file.exists(path)', returns: 'Boolean' },
+			{ name: 'isDirectory', kind: 'method', signature: 'file.isDirectory(path)', returns: 'Boolean', doc: 'Errors if the path does not exist.' },
+			{ name: 'size', kind: 'method', signature: 'file.size(path)', returns: 'Number', doc: 'Size in bytes. Errors if the path does not exist.' },
+			{ name: 'delete', kind: 'method', signature: 'file.delete(path)', doc: 'Removes a file or an **empty** directory — a non-empty directory is refused rather than wiped.' },
+			{ name: 'mkdir', kind: 'method', signature: 'file.mkdir(path)', doc: 'Creates the directory and any missing parents.' },
+			{ name: 'list', kind: 'method', signature: 'file.list(path)', returns: 'List', doc: 'Entry names in a directory, not full paths.' },
+			{ name: 'copy', kind: 'method', signature: 'file.copy(source, destination)', doc: 'Copies a file, preserving its permissions.' },
+			{ name: 'move', kind: 'method', signature: 'file.move(source, destination)', doc: 'Renames or moves a file.' }
 		]
 	},
 	{
@@ -74,29 +141,19 @@ const MODULES = [
 		doc: 'The interpreter itself — running code, extending the runtime, and inspecting state.',
 		members: [
 			{ name: 'version', kind: 'property', signature: 'ghost.version', returns: 'String', doc: 'The running interpreter\'s version string.' },
-			{ name: 'abort', kind: 'method', signature: 'ghost.abort(message)', doc: 'Stops execution and reports `message` as a runtime error.' },
-			{ name: 'execute', kind: 'method', signature: 'ghost.execute(source)', doc: 'Evaluates a string of Ghost source in the current environment.' },
-			{ name: 'extend', kind: 'method', signature: 'ghost.extend(name, value)', doc: 'Registers a value as a global under `name`.' },
-			{ name: 'identifiers', kind: 'method', signature: 'ghost.identifiers()', returns: 'List', doc: 'Returns the names currently bound in scope.' }
+			{ name: 'abort', kind: 'method', signature: 'ghost.abort(message)', doc: 'Stops the program, reporting `message` (or `null`, to abort silently) as a value error.' },
+			{ name: 'execute', kind: 'method', signature: 'ghost.execute(source)', doc: 'Parses and evaluates a string of Ghost source in the current scope. A syntax error in it is reported at this call.' },
+			{ name: 'extend', kind: 'method', signature: 'ghost.extend(pluginPath)', doc: 'Loads a Go plugin relative to the script\'s directory and calls its exported `Register()`, letting it register new library modules or functions at runtime.' },
+			{ name: 'identifiers', kind: 'method', signature: 'ghost.identifiers()', returns: 'List', doc: 'Every identifier currently bound in scope.' }
 		]
 	},
 	{
 		name: 'http',
 		source: 'ghost',
-		doc: 'A small HTTP server.',
+		doc: 'A small HTTP server, deliberately minimal.',
 		members: [
-			{ name: 'handle', kind: 'method', signature: 'http.handle(path, handler)', doc: 'Registers a handler function for a request path.' },
-			{ name: 'listen', kind: 'method', signature: 'http.listen(port)', doc: 'Starts serving on `port`. Blocks until the process ends.' }
-		]
-	},
-	{
-		name: 'io',
-		source: 'ghost',
-		doc: 'Reading and writing files, resolved relative to the running source file.\n\nUnder Lumen this is the right module for a game\'s own shipped data and the wrong one for saves — see `filesystem`.',
-		members: [
-			{ name: 'read', kind: 'method', signature: 'io.read(path)', returns: 'String', doc: 'Reads a file and returns its contents.' },
-			{ name: 'write', kind: 'method', signature: 'io.write(path, contents)', doc: 'Writes `contents` to a file, replacing what was there.' },
-			{ name: 'append', kind: 'method', signature: 'io.append(path, contents)', doc: 'Appends `contents` to the end of a file.' }
+			{ name: 'handle', kind: 'method', signature: 'http.handle(path, callback)', doc: 'Registers `callback(request)` for requests to `path`. `request` is a map with `method`, `host`, `contentLength`, `protocol`, `protocolMajor`, `protocolMinor` and `body`. A panic inside the handler answers a 500 rather than crashing the server.' },
+			{ name: 'listen', kind: 'method', signature: 'http.listen(port, [ready])', doc: 'Starts serving on `port`, calling `ready()` once, if given, right before blocking. Blocks until interrupted, then shuts down within 30 seconds.' }
 		]
 	},
 	{
@@ -104,28 +161,154 @@ const MODULES = [
 		source: 'ghost',
 		doc: 'Converting between JSON text and Ghost values.',
 		members: [
-			{ name: 'decode', kind: 'method', signature: 'json.decode(text)', doc: 'Parses JSON text into maps, lists, strings, numbers, booleans and null.' },
-			{ name: 'encode', kind: 'method', signature: 'json.encode(value)', returns: 'String', doc: 'Serialises a Ghost value to JSON text.' }
+			{ name: 'decode', kind: 'method', signature: 'json.decode(text)', doc: 'Parses JSON text into a list or map. Only an object or array is accepted at the top level — wrap a bare value in `[` and `]` to decode it.' },
+			{ name: 'encode', kind: 'method', signature: 'json.encode(value)', returns: 'String', doc: 'Serialises a list or map to JSON text. A map\'s keys have to be a string, number, or boolean.' }
 		]
 	},
 	{
 		name: 'math',
 		source: 'ghost',
-		doc: 'Numbers and trigonometry.\n\nLumen adds a great deal more to this same module — rounding, roots, angles, interpolation and randomness — rather than introducing a second one.',
+		doc: 'Numbers: arithmetic, trigonometry, linear algebra and statistics. Most of this broadcasts — a scalar operation applied to a list or a list of lists works elementwise, the same mechanism `+`/`*` already use on lists, so `math.add(a, b)` and `a + b` are the same operation reached two ways.',
 		members: [
 			{ name: 'pi', kind: 'property', signature: 'math.pi', returns: 'Number', doc: 'π, 3.14159…' },
 			{ name: 'tau', kind: 'property', signature: 'math.tau', returns: 'Number', doc: 'τ, a full turn in radians (2π).' },
 			{ name: 'e', kind: 'property', signature: 'math.e', returns: 'Number', doc: 'Euler\'s number, 2.71828…' },
+			{ name: 'phi', kind: 'property', signature: 'math.phi', returns: 'Number', doc: 'The golden ratio.' },
+			{ name: 'sqrt2', kind: 'property', signature: 'math.sqrt2', returns: 'Number' },
+			{ name: 'sqrtPi', kind: 'property', signature: 'math.sqrtPi', returns: 'Number' },
+			{ name: 'ln2', kind: 'property', signature: 'math.ln2', returns: 'Number' },
+			{ name: 'ln10', kind: 'property', signature: 'math.ln10', returns: 'Number' },
+			{ name: 'log2e', kind: 'property', signature: 'math.log2e', returns: 'Number' },
+			{ name: 'log10e', kind: 'property', signature: 'math.log10e', returns: 'Number' },
 			{ name: 'epsilon', kind: 'property', signature: 'math.epsilon', returns: 'Number', doc: 'The smallest difference two numbers can meaningfully have.' },
-			{ name: 'abs', kind: 'method', signature: 'math.abs(n)', returns: 'Number', doc: 'The absolute value of `n`.' },
+			{ name: 'smallestNumber', kind: 'property', signature: 'math.smallestNumber', returns: 'Number', doc: 'The smallest positive number representable.' },
+			{ name: 'largestNumber', kind: 'property', signature: 'math.largestNumber', returns: 'Number' },
+			{ name: 'infinity', kind: 'property', signature: 'math.infinity', returns: 'Number' },
+			{ name: 'nan', kind: 'property', signature: 'math.nan', returns: 'Number', doc: 'Not-a-number.' },
+			{ name: 'largestInteger', kind: 'property', signature: 'math.largestInteger', returns: 'Number' },
+			{ name: 'smallestInteger', kind: 'property', signature: 'math.smallestInteger', returns: 'Number' },
+
+			{ name: 'abs', kind: 'method', signature: 'math.abs(n)', returns: 'Number', doc: 'The absolute value of `n`. Broadcasts over a list or matrix.' },
+			{ name: 'sign', kind: 'method', signature: 'math.sign(n)', returns: 'Number', doc: '-1, 0 or 1.' },
+			{ name: 'floor', kind: 'method', signature: 'math.floor(n)', returns: 'Number' },
+			{ name: 'ceil', kind: 'method', signature: 'math.ceil(n)', returns: 'Number' },
+			{ name: 'truncate', kind: 'method', signature: 'math.truncate(n)', returns: 'Number', doc: 'Truncates toward zero, unlike `floor`.' },
+			{ name: 'round', kind: 'method', signature: 'math.round(n, [places])', returns: 'Number', doc: 'Rounds to the nearest whole number, or to `places` decimal places if given.' },
+
+			{ name: 'sqrt', kind: 'method', signature: 'math.sqrt(n)', returns: 'Number' },
+			{ name: 'cbrt', kind: 'method', signature: 'math.cbrt(n)', returns: 'Number', doc: 'Cube root.' },
+			{ name: 'square', kind: 'method', signature: 'math.square(n)', returns: 'Number', doc: 'n². Keeps an integer input an integer.' },
+			{ name: 'reciprocal', kind: 'method', signature: 'math.reciprocal(n)', returns: 'Number', doc: '1/n. Errors dividing by zero.' },
+			{ name: 'exp', kind: 'method', signature: 'math.exp(n)', returns: 'Number', doc: 'eⁿ' },
+			{ name: 'exp2', kind: 'method', signature: 'math.exp2(n)', returns: 'Number', doc: '2ⁿ' },
+			{ name: 'expm1', kind: 'method', signature: 'math.expm1(n)', returns: 'Number', doc: 'eⁿ − 1, accurately for `n` near zero.' },
+			{ name: 'log', kind: 'method', signature: 'math.log(n, [base])', returns: 'Number', doc: 'The natural logarithm, or the logarithm in `base` if given.' },
+			{ name: 'log2', kind: 'method', signature: 'math.log2(n)', returns: 'Number' },
+			{ name: 'log10', kind: 'method', signature: 'math.log10(n)', returns: 'Number' },
+			{ name: 'log1p', kind: 'method', signature: 'math.log1p(n)', returns: 'Number', doc: 'log(1 + n), accurately for `n` near zero.' },
+			{ name: 'pow', kind: 'method', signature: 'math.pow(base, exponent)', returns: 'Number', doc: 'An integer base to a non-negative integer exponent stays exact when it fits; otherwise this falls back to a float.' },
+			{ name: 'hypot', kind: 'method', signature: 'math.hypot(a, b)', returns: 'Number', doc: '√(a² + b²).' },
+
 			{ name: 'sin', kind: 'method', signature: 'math.sin(radians)', returns: 'Number', doc: 'The sine of an angle in radians.' },
 			{ name: 'cos', kind: 'method', signature: 'math.cos(radians)', returns: 'Number', doc: 'The cosine of an angle in radians.' },
 			{ name: 'tan', kind: 'method', signature: 'math.tan(radians)', returns: 'Number', doc: 'The tangent of an angle in radians.' },
-			{ name: 'max', kind: 'method', signature: 'math.max(a, b)', returns: 'Number', doc: 'The larger of two numbers.' },
-			{ name: 'min', kind: 'method', signature: 'math.min(a, b)', returns: 'Number', doc: 'The smaller of two numbers.' },
+			{ name: 'asin', kind: 'method', signature: 'math.asin(n)', returns: 'Number', doc: 'The arcsine of `n`, in radians.' },
+			{ name: 'acos', kind: 'method', signature: 'math.acos(n)', returns: 'Number', doc: 'The arccosine of `n`, in radians.' },
+			{ name: 'atan', kind: 'method', signature: 'math.atan(n)', returns: 'Number', doc: 'The arctangent of `n`, in radians.' },
+			{ name: 'atan2', kind: 'method', signature: 'math.atan2(y, x)', returns: 'Number', doc: 'The angle of the vector `(x, y)`, in radians, with the quadrant resolved.' },
+			{ name: 'sinh', kind: 'method', signature: 'math.sinh(n)', returns: 'Number' },
+			{ name: 'cosh', kind: 'method', signature: 'math.cosh(n)', returns: 'Number' },
+			{ name: 'tanh', kind: 'method', signature: 'math.tanh(n)', returns: 'Number' },
+			{ name: 'asinh', kind: 'method', signature: 'math.asinh(n)', returns: 'Number' },
+			{ name: 'acosh', kind: 'method', signature: 'math.acosh(n)', returns: 'Number' },
+			{ name: 'atanh', kind: 'method', signature: 'math.atanh(n)', returns: 'Number' },
+			{ name: 'degrees', kind: 'method', signature: 'math.degrees(radians)', returns: 'Number', doc: 'Radians converted to degrees.' },
+			{ name: 'radians', kind: 'method', signature: 'math.radians(degrees)', returns: 'Number', doc: 'Degrees converted to radians.' },
+
+			{ name: 'gamma', kind: 'method', signature: 'math.gamma(n)', returns: 'Number' },
+			{ name: 'logGamma', kind: 'method', signature: 'math.logGamma(n)', returns: 'Number', doc: 'The natural log of |Γ(n)|.' },
+			{ name: 'erf', kind: 'method', signature: 'math.erf(n)', returns: 'Number', doc: 'The error function.' },
+			{ name: 'erfc', kind: 'method', signature: 'math.erfc(n)', returns: 'Number', doc: 'The complementary error function.' },
+
+			{ name: 'add', kind: 'method', signature: 'math.add(a, b)', returns: 'Number', doc: 'The same operation `+` performs, callable as a value — useful passed to `reduce`, `map` and the like.' },
+			{ name: 'subtract', kind: 'method', signature: 'math.subtract(a, b)', returns: 'Number' },
+			{ name: 'multiply', kind: 'method', signature: 'math.multiply(a, b)', returns: 'Number' },
+			{ name: 'divide', kind: 'method', signature: 'math.divide(a, b)', returns: 'Number', doc: 'Errors dividing by zero.' },
+			{ name: 'mod', kind: 'method', signature: 'math.mod(a, b)', returns: 'Number', doc: 'Errors dividing by zero.' },
+			{ name: 'remainder', kind: 'method', signature: 'math.remainder(a, b)', returns: 'Number', doc: 'The IEEE 754 remainder, which can differ in sign from `mod`.' },
+			{ name: 'copySign', kind: 'method', signature: 'math.copySign(a, b)', returns: 'Number', doc: 'The magnitude of `a` with the sign of `b`.' },
+			{ name: 'maximum', kind: 'method', signature: 'math.maximum(a, b)', returns: 'Number', doc: 'The elementwise pairwise maximum — distinct from the reduction `math.max`, which takes many values and answers one.' },
+			{ name: 'minimum', kind: 'method', signature: 'math.minimum(a, b)', returns: 'Number', doc: 'The elementwise pairwise minimum, distinct from the reduction `math.min`.' },
+
+			{ name: 'isNaN', kind: 'method', signature: 'math.isNaN(n)', returns: 'Boolean' },
+			{ name: 'isFinite', kind: 'method', signature: 'math.isFinite(n)', returns: 'Boolean' },
+			{ name: 'isInfinite', kind: 'method', signature: 'math.isInfinite(n)', returns: 'Boolean' },
+			{ name: 'isInteger', kind: 'method', signature: 'math.isInteger(n)', returns: 'Boolean' },
+			{ name: 'isEven', kind: 'method', signature: 'math.isEven(n)', returns: 'Boolean' },
+			{ name: 'isOdd', kind: 'method', signature: 'math.isOdd(n)', returns: 'Boolean' },
 			{ name: 'isPositive', kind: 'method', signature: 'math.isPositive(n)', returns: 'Boolean', doc: 'Whether `n` is greater than zero.' },
 			{ name: 'isNegative', kind: 'method', signature: 'math.isNegative(n)', returns: 'Boolean', doc: 'Whether `n` is less than zero.' },
-			{ name: 'isZero', kind: 'method', signature: 'math.isZero(n)', returns: 'Boolean', doc: 'Whether `n` is zero.' }
+			{ name: 'isZero', kind: 'method', signature: 'math.isZero(n)', returns: 'Boolean', doc: 'Whether `n` is zero.' },
+			{ name: 'isClose', kind: 'method', signature: 'math.isClose(a, b, [tolerance])', returns: 'Boolean', doc: 'A combined absolute-and-relative tolerance comparison (default `1e-9`) — the right way to compare floats after arithmetic, where `==` cannot be trusted.' },
+
+			{ name: 'clamp', kind: 'method', signature: 'math.clamp(value, low, high)', returns: 'Number', doc: 'Errors if `low` is greater than `high`.' },
+			{ name: 'lerp', kind: 'method', signature: 'math.lerp(from, to, amount)', returns: 'Number', doc: 'A point `amount` of the way from `from` to `to`.' },
+			{ name: 'smoothstep', kind: 'method', signature: 'math.smoothstep(low, high, value)', returns: 'Number', doc: 'An eased interpolation, clamped to 0–1 at the edges.' },
+			{ name: 'noise', kind: 'method', signature: 'math.noise(x, [y])', returns: 'Number', doc: 'Smoothly varying value noise in [0, 1) — continuous and reproducible for the same input, unlike jittery random numbers. For terrain, clouds and other things that should look organic.' },
+
+			{ name: 'randomInt', kind: 'method', signature: 'math.randomInt(n)', returns: 'Number', doc: 'A random whole number: `[1, n]` with one argument, `[low, high]` with two (`math.randomInt(low, high)`). Draws on the same generator `random.seed()` seeds.' },
+			{ name: 'randomSeed', kind: 'method', signature: 'math.randomSeed(n)', doc: 'Seeds the generator `random.seed()` also seeds, making the sequence that follows repeatable.' },
+
+			{ name: 'arange', kind: 'method', signature: 'math.arange(stop)', returns: 'List', doc: 'Counts up, **excluding** `stop`. Also takes `arange(start, stop)` and `arange(start, stop, step)`; errors if `step` is zero.' },
+			{ name: 'linspace', kind: 'method', signature: 'math.linspace(start, stop, count)', returns: 'List', doc: '`count` evenly spaced points, **including both endpoints**.' },
+			{ name: 'zeros', kind: 'method', signature: 'math.zeros(n)', returns: 'List', doc: 'A list of zeros, or `zeros(rows, cols)` for a matrix of them.' },
+			{ name: 'ones', kind: 'method', signature: 'math.ones(n)', returns: 'List', doc: 'A list of ones, or `ones(rows, cols)` for a matrix of them.' },
+			{ name: 'full', kind: 'method', signature: 'math.full(n, fill)', returns: 'List', doc: 'A list filled with `fill`, or `full(rows, cols, fill)` for a matrix.' },
+			{ name: 'identity', kind: 'method', signature: 'math.identity(size)', returns: 'List', doc: 'The `size` × `size` identity matrix.' },
+			{ name: 'reshape', kind: 'method', signature: 'math.reshape(values, dim, ...)', returns: 'List', doc: 'Lays a flat or nested list of numbers into new dimensions. One dimension may be `-1` to infer it.' },
+			{ name: 'flatten', kind: 'method', signature: 'math.flatten(values, ...)', returns: 'List', doc: 'Collapses arbitrary nesting into one flat list.' },
+			{ name: 'shape', kind: 'method', signature: 'math.shape(list)', returns: 'List', doc: 'The dimensions, outermost first. Stops at the first ragged (non-rectangular) level.' },
+			{ name: 'transpose', kind: 'method', signature: 'math.transpose(matrix)', returns: 'List', doc: 'Swaps rows and columns.' },
+
+			{ name: 'dot', kind: 'method', signature: 'math.dot(a, b)', doc: 'Two vectors give a number; a matrix and a vector give a vector; two matrices give a matrix (matrix multiplication). Errors on a shape mismatch.' },
+			{ name: 'matmul', kind: 'method', signature: 'math.matmul(a, b)', doc: 'An alias for `dot` — the same operation.' },
+			{ name: 'cross', kind: 'method', signature: 'math.cross(a, b)', doc: '2D vectors give the single scalar their cross product yields; 3D vectors give the perpendicular vector.' },
+			{ name: 'outer', kind: 'method', signature: 'math.outer(a, b)', returns: 'List', doc: 'The outer product — a matrix as tall as `a` and as wide as `b`.' },
+			{ name: 'norm', kind: 'method', signature: 'math.norm(vector, [order])', returns: 'Number', doc: 'Vector length. Default order 2 (Euclidean); order 1 sums `|x|`; `math.infinity` takes the largest `|x|`. Errors if order is not positive.' },
+			{ name: 'normalize', kind: 'method', signature: 'math.normalize(vector)', returns: 'List', doc: 'Scaled to unit length, same direction. Errors on a zero-length vector.' },
+			{ name: 'distance', kind: 'method', signature: 'math.distance(x1, y1, x2, y2)', returns: 'Number', doc: 'The distance between two points. Also takes two point lists: `math.distance([0, 0], [3, 4])`.' },
+			{ name: 'angle', kind: 'method', signature: 'math.angle(x1, y1, x2, y2)', returns: 'Number', doc: 'The angle from one point to another, in radians, all quadrants resolved. Also takes two point lists.' },
+
+			{ name: 'trace', kind: 'method', signature: 'math.trace(matrix)', returns: 'Number', doc: 'The sum of the diagonal.' },
+			{ name: 'determinant', kind: 'method', signature: 'math.determinant(matrix)', returns: 'Number', doc: 'Zero for a singular matrix.' },
+			{ name: 'inverse', kind: 'method', signature: 'math.inverse(matrix)', returns: 'List', doc: 'Errors if the matrix is singular.' },
+			{ name: 'solve', kind: 'method', signature: 'math.solve(a, b)', returns: 'List', doc: 'Solves `a·x = b` directly, without forming the inverse. `b` may be a vector or a matrix of several right-hand sides. Errors on a singular system.' },
+
+			{ name: 'sum', kind: 'method', signature: 'math.sum(value, ...)', returns: 'Number', doc: 'Takes values spread across arguments, as one list, or as nested lists (flattened) — `math.sum(1, 2, 3) == math.sum([1, 2, 3])`. Every reduction below takes values the same three interchangeable ways, and errors on empty input.' },
+			{ name: 'product', kind: 'method', signature: 'math.product(value, ...)', returns: 'Number', doc: 'Starts from 1.' },
+			{ name: 'mean', kind: 'method', signature: 'math.mean(value, ...)', returns: 'Number' },
+			{ name: 'median', kind: 'method', signature: 'math.median(value, ...)', returns: 'Number', doc: 'Averages the two middle values on an even count.' },
+			{ name: 'mode', kind: 'method', signature: 'math.mode(value, ...)', returns: 'Number', doc: 'The most frequent value; ties break toward the smallest.' },
+			{ name: 'variance', kind: 'method', signature: 'math.variance(value, ...)', returns: 'Number', doc: 'Population variance (divided by N).' },
+			{ name: 'sampleVariance', kind: 'method', signature: 'math.sampleVariance(value, ...)', returns: 'Number', doc: 'Sample variance (divided by N − 1). Errors with fewer than two values.' },
+			{ name: 'standardDeviation', kind: 'method', signature: 'math.standardDeviation(value, ...)', returns: 'Number', doc: 'The square root of the population variance.' },
+			{ name: 'sampleStandardDeviation', kind: 'method', signature: 'math.sampleStandardDeviation(value, ...)', returns: 'Number', doc: 'The square root of the sample variance. Errors with fewer than two values.' },
+			{ name: 'min', kind: 'method', signature: 'math.min(value, ...)', returns: 'Number', doc: 'The smallest of any number of values — a reduction, unlike the elementwise `math.minimum`.' },
+			{ name: 'max', kind: 'method', signature: 'math.max(value, ...)', returns: 'Number', doc: 'The largest of any number of values — a reduction, unlike the elementwise `math.maximum`.' },
+			{ name: 'argmin', kind: 'method', signature: 'math.argmin(value, ...)', returns: 'Number', doc: 'The index of the first-smallest value, in flattened order.' },
+			{ name: 'argmax', kind: 'method', signature: 'math.argmax(value, ...)', returns: 'Number', doc: 'The index of the first-largest value.' },
+			{ name: 'cumulativeSum', kind: 'method', signature: 'math.cumulativeSum(value, ...)', returns: 'List', doc: 'Running totals, the same length as the input.' },
+			{ name: 'cumulativeProduct', kind: 'method', signature: 'math.cumulativeProduct(value, ...)', returns: 'List', doc: 'Running products.' },
+			{ name: 'gcd', kind: 'method', signature: 'math.gcd(value, ...)', returns: 'Number' },
+			{ name: 'lcm', kind: 'method', signature: 'math.lcm(value, ...)', returns: 'Number', doc: 'Errors on overflow.' },
+			{ name: 'percentile', kind: 'method', signature: 'math.percentile(values, p)', returns: 'Number', doc: '`p` on a 0–100 scale, interpolated between neighbours.' },
+			{ name: 'quantile', kind: 'method', signature: 'math.quantile(values, q)', returns: 'Number', doc: 'The same as `percentile`, with `q` on a 0–1 scale.' },
+			{ name: 'sort', kind: 'method', signature: 'math.sort(values, [descending])', returns: 'List', doc: 'Ascending by default.' },
+			{ name: 'unique', kind: 'method', signature: 'math.unique(value, ...)', returns: 'List', doc: 'Duplicates dropped, first-seen order kept.' },
+			{ name: 'factorial', kind: 'method', signature: 'math.factorial(n)', returns: 'Number', doc: 'Falls back to a float, via Γ, if the exact result would overflow. Errors if `n` is negative.' },
+			{ name: 'isPrime', kind: 'method', signature: 'math.isPrime(n)', returns: 'Boolean', doc: 'False for a non-integer.' },
+			{ name: 'combinations', kind: 'method', signature: 'math.combinations(n, k)', returns: 'Number', doc: 'n choose k.' },
+			{ name: 'permutations', kind: 'method', signature: 'math.permutations(n, k)', returns: 'Number', doc: 'Like `combinations`, but order matters.' }
 		]
 	},
 	{
@@ -133,44 +316,39 @@ const MODULES = [
 		source: 'ghost',
 		doc: 'The host operating system and process.',
 		members: [
-			{ name: 'name', kind: 'method', signature: 'os.name()', returns: 'String', doc: 'The name of the host operating system.' },
+			{ name: 'name', kind: 'property', signature: 'os.name', returns: 'String', doc: 'The name of the host operating system.' },
 			{ name: 'args', kind: 'method', signature: 'os.args()', returns: 'List', doc: 'The command line arguments the program was started with.' },
-			{ name: 'clock', kind: 'method', signature: 'os.clock()', returns: 'Number', doc: 'Processor time consumed, in seconds.' },
-			{ name: 'exit', kind: 'method', signature: 'os.exit([code])', doc: 'Ends the process with an optional exit code.' }
+			{ name: 'exit', kind: 'method', signature: 'os.exit(status, [message])', doc: 'Ends the process with `status`, printing `message` first if given. Every argument is validated before anything is printed or the process exits.' },
+			{ name: 'sleep', kind: 'method', signature: 'os.sleep(milliseconds)', doc: 'Pauses the program. Errors if `milliseconds` is negative.\n\nInside a game loop this stalls the frame — reach for it rarely, or not at all.' }
+		]
+	},
+	{
+		name: 'path',
+		source: 'ghost',
+		doc: 'Path string manipulation — never touches the filesystem, unlike `file`.',
+		members: [
+			{ name: 'join', kind: 'method', signature: 'path.join(part, ...)', returns: 'String', doc: 'Joins one or more path segments.' },
+			{ name: 'basename', kind: 'method', signature: 'path.basename(p)', returns: 'String', doc: 'The last path element.' },
+			{ name: 'dirname', kind: 'method', signature: 'path.dirname(p)', returns: 'String', doc: 'Everything but the last element.' },
+			{ name: 'extname', kind: 'method', signature: 'path.extname(p)', returns: 'String', doc: 'The extension, including the leading dot — an empty string when there is none.' },
+			{ name: 'isAbsolute', kind: 'method', signature: 'path.isAbsolute(p)', returns: 'Boolean' }
 		]
 	},
 	{
 		name: 'random',
 		source: 'ghost',
-		doc: 'Random numbers.\n\nA game wanting a number in a range, or a repeatable sequence per level, is better served by Lumen\'s `math.random()` and `math.randomSeed()`, which draw on a generator nothing else in the process can disturb.',
+		doc: 'Random numbers, from the same generator `math`\'s `randomInt`/`randomSeed` use.',
 		members: [
-			{ name: 'random', kind: 'method', signature: 'random.random()', returns: 'Number', doc: 'A random number.' },
-			{ name: 'seed', kind: 'method', signature: 'random.seed(n)', doc: 'Seeds the generator, making the sequence that follows repeatable.' }
-		]
-	},
-	{
-		name: 'time',
-		source: 'ghost',
-		doc: 'Clock readings and delays.',
-		members: [
-			{ name: 'now', kind: 'method', signature: 'time.now()', returns: 'Number', doc: 'The current time.' },
-			{ name: 'sleep', kind: 'method', signature: 'time.sleep(duration)', doc: 'Pauses execution.\n\nInside a game loop this stalls the frame — use `timer.sleep()` deliberately, or not at all.' },
-			{ name: 'nanosecond', kind: 'property', signature: 'time.nanosecond', returns: 'Number', doc: 'One nanosecond, as a duration.' },
-			{ name: 'microsecond', kind: 'property', signature: 'time.microsecond', returns: 'Number', doc: 'One microsecond, as a duration.' },
-			{ name: 'millisecond', kind: 'property', signature: 'time.millisecond', returns: 'Number', doc: 'One millisecond, as a duration.' },
-			{ name: 'second', kind: 'property', signature: 'time.second', returns: 'Number', doc: 'One second, as a duration.' },
-			{ name: 'minute', kind: 'property', signature: 'time.minute', returns: 'Number', doc: 'One minute, as a duration.' },
-			{ name: 'hour', kind: 'property', signature: 'time.hour', returns: 'Number', doc: 'One hour, as a duration.' },
-			{ name: 'day', kind: 'property', signature: 'time.day', returns: 'Number', doc: 'One day, as a duration.' },
-			{ name: 'week', kind: 'property', signature: 'time.week', returns: 'Number', doc: 'One week, as a duration.' },
-			{ name: 'month', kind: 'property', signature: 'time.month', returns: 'Number', doc: 'One month, as a duration.' },
-			{ name: 'year', kind: 'property', signature: 'time.year', returns: 'Number', doc: 'One year, as a duration.' }
+			{ name: 'random', kind: 'method', signature: 'random.random([max]) or random.random(min, max)', returns: 'Number', doc: 'A uniform random number. No arguments: `(0, 1)`. One argument: `(0, max)`. Two: `(min, max)`.' },
+			{ name: 'seed', kind: 'method', signature: 'random.seed([n])', doc: 'Seeds the generator. With no argument, reseeds from the current time.' },
+			{ name: 'currentSeed', kind: 'property', signature: 'random.currentSeed', returns: 'Number', doc: 'The seed currently driving the generator — a read-only counterpart to `seed()`, deliberately a different name so no getter and setter ever share a word.' }
 		]
 	}
 ];
 
 /**
- * Methods on built-in values. Maps have none — indexing is how you read them.
+ * Methods on built-in values. Every one of these is always in scope, needing
+ * no `import` — they live on the value itself, not on a module.
  *
  * @type {ObjectType[]}
  */
@@ -183,7 +361,7 @@ const TYPES = [
 			{ name: 'length', kind: 'method', signature: 'length()', returns: 'Number', doc: 'The number of characters, counted as runes rather than bytes.' },
 			{ name: 'format', kind: 'method', signature: 'format(value, ...)', returns: 'String', doc: 'Treats the string as a format template and fills in the arguments.\n\n```ghost\n"> %s roars.".format(this.breed)\n```' },
 			{ name: 'split', kind: 'method', signature: 'split(separator)', returns: 'List', doc: 'Splits the string on `separator` and returns the pieces as a list.' },
-			{ name: 'replace', kind: 'method', signature: 'replace(old, new)', returns: 'String', doc: 'Replaces every occurrence of `old` with `new`.' },
+			{ name: 'replace', kind: 'method', signature: 'replace(old, new)', returns: 'String', doc: 'Replaces every literal occurrence of `old` with `new`.' },
 			{ name: 'startsWith', kind: 'method', signature: 'startsWith(prefix)', returns: 'Boolean', doc: 'Whether the string begins with `prefix`.' },
 			{ name: 'endsWith', kind: 'method', signature: 'endsWith(suffix)', returns: 'Boolean', doc: 'Whether the string ends with `suffix`.' },
 			{ name: 'trim', kind: 'method', signature: 'trim()', returns: 'String', doc: 'Removes whitespace from both ends.' },
@@ -191,11 +369,11 @@ const TYPES = [
 			{ name: 'trimEnd', kind: 'method', signature: 'trimEnd()', returns: 'String', doc: 'Removes whitespace from the end.' },
 			{ name: 'toLowerCase', kind: 'method', signature: 'toLowerCase()', returns: 'String', doc: 'The string in lowercase.' },
 			{ name: 'toUpperCase', kind: 'method', signature: 'toUpperCase()', returns: 'String', doc: 'The string in uppercase.' },
-			{ name: 'toNumber', kind: 'method', signature: 'toNumber()', returns: 'Number', doc: 'Parses the string as a number.' },
+			{ name: 'toNumber', kind: 'method', signature: 'toNumber()', returns: 'Number', doc: 'Parses the string as a number — an integer first, then a float. Errors, with help, if it parses as neither.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'The string itself.' },
 			{ name: 'matches', kind: 'method', signature: 'matches(subject)', returns: 'Boolean', doc: 'Whether `subject` matches this string used as a regular expression.\n\n**The receiver is the pattern, not the subject.** `"^h".matches(name)` tests `name`.' },
 			{ name: 'find', kind: 'method', signature: 'find(subject)', returns: 'String', doc: 'The first match of this string, used as a regular expression, within `subject`. Returns an empty string when nothing matches.\n\n**The receiver is the pattern, not the subject.**' },
-			{ name: 'findAll', kind: 'method', signature: 'findAll(subject)', returns: 'List', doc: 'The first match and its capture groups, as a list.\n\n**The receiver is the pattern, not the subject.**' }
+			{ name: 'findAll', kind: 'method', signature: 'findAll(subject)', returns: 'List', doc: 'The first match\'s capture groups, as a list — not every match in `subject`, despite the name.\n\n**The receiver is the pattern, not the subject.**' }
 		]
 	},
 	{
@@ -205,12 +383,23 @@ const TYPES = [
 		methods: [
 			{ name: 'length', kind: 'method', signature: 'length()', returns: 'Number', doc: 'The number of elements.' },
 			{ name: 'push', kind: 'method', signature: 'push(value)', returns: 'Number', doc: 'Appends a value to the end and returns the new length.' },
-			{ name: 'pop', kind: 'method', signature: 'pop()', doc: 'Removes and returns the **first** element, not the last, and returns null when the list is empty.' },
-			{ name: 'first', kind: 'method', signature: 'first()', doc: 'The first element, or null when the list is empty.' },
-			{ name: 'last', kind: 'method', signature: 'last()', doc: 'The last element, or null when the list is empty.' },
-			{ name: 'tail', kind: 'method', signature: 'tail()', returns: 'List', doc: 'A new list holding everything but the first element.' },
+			{ name: 'pop', kind: 'method', signature: 'pop()', doc: 'Removes and returns the **last** element, mirroring `push` — a list used as a stack grows and shrinks from the same end. Returns null when the list is empty.\n\nFor the first element, see `shift`.' },
+			{ name: 'shift', kind: 'method', signature: 'shift()', doc: 'Removes and returns the **first** element, sliding everything else down. Returns null when the list is empty. This is what `pop` did before `pop` was made to match `push` and act on the other end.' },
+			{ name: 'first', kind: 'method', signature: 'first()', doc: 'The first element, or null when the list is empty. Does not remove it.' },
+			{ name: 'last', kind: 'method', signature: 'last()', doc: 'The last element, or null when the list is empty. Does not remove it.' },
+			{ name: 'tail', kind: 'method', signature: 'tail()', returns: 'List', doc: 'A new list holding everything but the first element, or null when the list is empty.' },
 			{ name: 'join', kind: 'method', signature: 'join(separator)', returns: 'String', doc: 'Joins the elements into a string, separated by `separator`.' },
-			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'The list rendered as a string.' }
+			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'The list rendered as a string.' },
+			{ name: 'concat', kind: 'method', signature: 'concat(other)', returns: 'List', doc: 'Joins two lists end to end into a new list, leaving both untouched. Not what `+` does on lists — that is elementwise arithmetic.' },
+			{ name: 'contains', kind: 'method', signature: 'contains(value)', returns: 'Boolean', doc: 'Whether `value` appears in the list, comparing contents the way `==` does.' },
+			{ name: 'reverse', kind: 'method', signature: 'reverse()', returns: 'List', doc: 'A new, reversed list.' },
+			{ name: 'slice', kind: 'method', signature: 'slice(start, [end])', returns: 'List', doc: 'The elements from `start` up to, but not including, `end`, which defaults to the length of the list.' },
+			{ name: 'sort', kind: 'method', signature: 'sort([comparator])', returns: 'List', doc: 'A new, sorted list. With no comparator, sorts a list of only numbers or only strings by natural order; anything else needs a comparator `(a, b) -> negative/zero/positive number`.' },
+			{ name: 'unique', kind: 'method', signature: 'unique()', returns: 'List', doc: 'A new list with repeats dropped, keeping first-seen order.' },
+			{ name: 'each', kind: 'method', signature: 'each(fn)', returns: 'List', doc: 'Calls `fn(element, index)` once per element for the side effect, and returns the list itself so a call can chain.' },
+			{ name: 'map', kind: 'method', signature: 'map(fn)', returns: 'List', doc: 'A new list built by calling `fn(element, index)` on every element.' },
+			{ name: 'filter', kind: 'method', signature: 'filter(fn)', returns: 'List', doc: 'A new list keeping the elements `fn(element, index)` answers true for.' },
+			{ name: 'reduce', kind: 'method', signature: 'reduce(fn, [initial])', doc: 'Folds the list to a single value with `fn(accumulator, element, index)`, left to right. With no `initial`, the first element seeds it — an empty list then needs one.' }
 		]
 	},
 	{
@@ -218,9 +407,31 @@ const TYPES = [
 		source: 'ghost',
 		doc: 'A number. Ghost does not separate integers from floats.',
 		methods: [
-			{ name: 'round', kind: 'method', signature: 'round()', returns: 'Number', doc: 'The number rounded to the nearest whole number.' },
-			{ name: 'floor', kind: 'method', signature: 'floor()', returns: 'Number', doc: 'The largest whole number no greater than this one.' },
+			{ name: 'round', kind: 'method', signature: 'round([places])', returns: 'Number', doc: 'Rounded to the nearest whole number, or to `places` decimal places if given. An already-whole number is returned unchanged.' },
+			{ name: 'floor', kind: 'method', signature: 'floor()', returns: 'Number', doc: 'The largest whole number no greater than this one. An already-whole number is returned unchanged.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'The number rendered as a string.' }
+		]
+	},
+	{
+		name: 'Map',
+		source: 'ghost',
+		doc: 'A collection of key/value pairs. A key has to be a string, number, or boolean.',
+		methods: [
+			{ name: 'get', kind: 'method', signature: 'get(key, [fallback])', doc: 'The value at `key`, or `fallback` if it is absent — or null with no fallback. The same rule `map[key]` indexing follows.' },
+			{ name: 'has', kind: 'method', signature: 'has(key)', returns: 'Boolean', doc: 'Whether `key` is present, regardless of its value — the distinction `get` alone cannot make, since a key can map to null on purpose.' },
+			{ name: 'set', kind: 'method', signature: 'set(key, value)', returns: 'Map', doc: 'Adds or overwrites a key, and returns the map itself so a call can chain.' },
+			{ name: 'keys', kind: 'method', signature: 'keys()', returns: 'List' },
+			{ name: 'values', kind: 'method', signature: 'values()', returns: 'List' },
+			{ name: 'length', kind: 'method', signature: 'length()', returns: 'Number', doc: 'The number of pairs.' },
+			{ name: 'merge', kind: 'method', signature: 'merge(other)', returns: 'Map', doc: 'A new map holding this map\'s pairs and another\'s, leaving both untouched. Where a key appears in both, `other`\'s value wins.' }
+		]
+	},
+	{
+		name: 'Date',
+		source: 'ghost',
+		doc: 'An instant in time, always UTC. Returned by the `date` module\'s functions, never constructed directly.\n\nCompares directly with `<`, `>`, `<=`, `>=`, `==` — there is no `isBefore()`/`isAfter()` method. Supports no arithmetic operators; use the `date` module\'s functions.',
+		methods: [
+			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'ISO 8601 / RFC3339, e.g. `2024-01-15T09:30:00Z`.' }
 		]
 	}
 ];

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -15,10 +15,12 @@ const lumen = require('./lumen');
  * `ghost.lumen.enable`.
  *
  * Lumen is not a separate language — a Lumen game is Ghost source — so the two
- * surfaces are merged rather than kept apart. Where they overlap they are
- * genuinely one thing at runtime: Lumen registers its extra maths onto Ghost's
- * own `math` module rather than introducing a second, so the merge here mirrors
- * what the interpreter does.
+ * surfaces are merged rather than kept apart. They no longer overlap at
+ * runtime the way they once did: Ghost's own `math` module grew everything
+ * Lumen used to bolt onto it, so Lumen's modules today are simply appended
+ * under their own `lumen:` scheme, each requiring its own `import` exactly
+ * like Ghost's `ghost:` modules do — only `console` (and the global `type()`
+ * function) are ever reachable without one.
  *
  * @typedef {object} Api
  * @property {boolean} lumen                    Whether the Lumen surface is included.
@@ -48,17 +50,7 @@ function build(withLumen) {
 	}
 
 	/** @type {Module[]} */
-	const modules = ghost.MODULES.map((module) => {
-		if (!withLumen || module.name !== 'math') {
-			return module;
-		}
-
-		// Lumen registers its additions onto Ghost's math module, so a game sees
-		// one module with both sets of methods.
-		return Object.assign({}, module, {
-			members: module.members.concat(lumen.MATH_EXTENSIONS)
-		});
-	});
+	const modules = ghost.MODULES.slice();
 
 	if (withLumen) {
 		modules.push(...lumen.MODULES);
@@ -123,6 +115,38 @@ function findTypeMethod(api, typeName, methodName) {
 	const member = type.methods.find((candidate) => candidate.name === methodName);
 
 	return member ? { type, member } : undefined;
+}
+
+/**
+ * Finds a `new`-able class exported by a specific scheme module — `import {
+ * Spritesheet } from "lumen:image"` needs to know that `Spritesheet` really
+ * is one of `image`'s exports before binding it, the same check the
+ * interpreter itself makes at import time.
+ *
+ * @param {Api} api
+ * @param {import('./types').Source} scheme
+ * @param {string} moduleName
+ * @param {string} className
+ * @returns {ObjectType | undefined}
+ */
+function findClass(api, scheme, moduleName, className) {
+	const type = api.typeByName.get(className);
+
+	return type && type.source === scheme && type.module === moduleName ? type : undefined;
+}
+
+/**
+ * Every class a scheme module exports — what `import * from "scheme:name"`
+ * and the combined form's `{ * }` pull in alongside a module's methods and
+ * properties.
+ *
+ * @param {Api} api
+ * @param {import('./types').Source} scheme
+ * @param {string} moduleName
+ * @returns {ObjectType[]}
+ */
+function classesOf(api, scheme, moduleName) {
+	return api.types.filter((type) => type.source === scheme && type.module === moduleName);
 }
 
 /**
@@ -205,6 +229,8 @@ module.exports = {
 	build,
 	findModuleMember,
 	findTypeMethod,
+	findClass,
+	classesOf,
 	findMethodEverywhere,
 	allMethods,
 	findFunction,

--- a/src/api/lumen.js
+++ b/src/api/lumen.js
@@ -6,12 +6,21 @@
  *
  * Lumen is a 2D engine that a game drives entirely from Ghost, so there is no
  * separate Lumen syntax — a Lumen game is `.ghost` files. What Lumen adds is a
- * set of modules registered before the game runs, a handful of object types its
- * loaders hand back, and the callbacks the engine looks for by name.
+ * set of modules registered under its own `lumen:` import scheme, a handful
+ * of object types its modules hand back as `new`-able classes, and the
+ * callbacks the engine looks for by name.
  *
- * Transcribed from `modules/` (what is registered), `engine/` (the `Method`
- * switch on each object type and the callback names in `events.go`), and the
- * signatures documented in Lumen's README.
+ * Every module here needs `import ... from "lumen:name"` before a script can
+ * use it — nothing is global. Transcribed from `modules/modules.go` (which
+ * modules and classes are registered, and under which scheme), `engine/`
+ * (the `Method` switch on each object type and the callback names in
+ * `events.go`), and the example games under `examples/`.
+ *
+ * Lumen no longer touches Ghost's `math` module at all — the engine has no
+ * `math.go` under `modules/`, and everything the old Lumen bolted on
+ * (`clamp`, `lerp`, `noise`, `randomInt`, the vector/matrix functions…) now
+ * ships natively in Ghost's own `ghost:math`, imported the same way in a
+ * Lumen game as anywhere else.
  */
 
 /** @typedef {import('./types').Member} Member */
@@ -64,7 +73,7 @@ const MODULES = [
 
 			{ name: 'push', kind: 'method', signature: "canvas.push(['all'])", doc: 'Saves the current transform. `push(\'all\')` saves the drawing state with it.' },
 			{ name: 'pop', kind: 'method', signature: 'canvas.pop()', doc: 'Restores the transform saved by the matching `push()`.' },
-			{ name: 'origin', kind: 'method', signature: 'canvas.origin()', doc: 'Resets the transform to the identity.' },
+			{ name: 'origin', kind: 'method', signature: 'canvas.origin()', doc: 'Goes back to the game\'s own base transform — not necessarily the identity.' },
 			{ name: 'translate', kind: 'method', signature: 'canvas.translate(x, y)', doc: 'Shifts everything drawn afterwards. This is how a camera is written.' },
 			{ name: 'rotate', kind: 'method', signature: 'canvas.rotate(radians)', doc: 'Rotates everything drawn afterwards.' },
 			{ name: 'scale', kind: 'method', signature: 'canvas.scale(x, [y])', doc: 'Scales everything drawn afterwards. One argument scales both axes.' },
@@ -73,10 +82,8 @@ const MODULES = [
 			{ name: 'toWorld', kind: 'method', signature: 'canvas.toWorld(x, y)', doc: 'Converts a point from screen coordinates to world coordinates.' },
 			{ name: 'getVisible', kind: 'method', signature: 'canvas.getVisible()', doc: 'The rectangle of the world currently on screen — what a tilemap needs to draw only the tiles in view.' },
 
-			{ name: 'newTarget', kind: 'method', signature: 'canvas.newTarget(w, h)', returns: 'Target', doc: 'Creates an off-screen surface to draw into.' },
 			{ name: 'setTarget', kind: 'method', signature: 'canvas.setTarget([target])', doc: 'Directs drawing into a target, or back to the window when called with nothing.\n\nSetting a target resets the transform, because a target is its own screen: `(0, 0)` is its corner, not the window\'s. Clearing it restores the window\'s transform.' },
-			{ name: 'newQuad', kind: 'method', signature: 'canvas.newQuad(x, y, w, h)', returns: 'Quad', doc: 'Creates a quad — a rectangle of a texture.' },
-			{ name: 'screenshot', kind: 'method', signature: 'canvas.screenshot(filename)', doc: 'Writes the current frame to an image file.' }
+			{ name: 'screenshot', kind: 'method', signature: 'canvas.screenshot(filename)', returns: 'String', doc: 'Writes the current frame to an image file and returns the path written.' }
 		]
 	},
 	{
@@ -86,8 +93,8 @@ const MODULES = [
 		members: [
 			{ name: 'rgb', kind: 'method', signature: 'color.rgb(r, g, b, [a])', returns: 'Color', doc: 'A colour from 0–255 components.' },
 			{ name: 'rgba', kind: 'method', signature: 'color.rgba(r, g, b, [a])', returns: 'Color', doc: 'A colour from 0–255 components.' },
-			{ name: 'hex', kind: 'method', signature: "color.hex('#ff8800')", returns: 'Color', doc: 'A colour from a hex string.' },
-			{ name: 'hsl', kind: 'method', signature: 'color.hsl(h, s, l, [a])', returns: 'Color', doc: 'A colour from hue, saturation and lightness.' },
+			{ name: 'hex', kind: 'method', signature: "color.hex('#ff8800')", returns: 'Color', doc: 'A colour from a hex string: `#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`. The `#` is optional.' },
+			{ name: 'hsl', kind: 'method', signature: 'color.hsl(h, s, l, [a])', returns: 'Color', doc: 'A colour from hue (degrees), saturation, lightness and alpha (0–1).' },
 
 			{ name: 'black', kind: 'property', signature: 'color.black', returns: 'Color', doc: 'Black.' },
 			{ name: 'white', kind: 'property', signature: 'color.white', returns: 'Color', doc: 'White.' },
@@ -109,33 +116,27 @@ const MODULES = [
 	{
 		name: 'image',
 		source: 'lumen',
-		doc: 'Loading textures and cutting them up.',
-		members: [
-			{ name: 'load', kind: 'method', signature: 'image.load(path)', returns: 'Image', doc: 'Loads an image. Paths resolve against the directory the entry file is in.\n\nLoading a path a second time hands back the texture already in memory, so loading one sheet from two places costs one texture.' },
-			{ name: 'newQuad', kind: 'method', signature: 'image.newQuad(x, y, w, h)', returns: 'Quad', doc: 'Creates a quad — a rectangle of a texture.' },
-			{ name: 'newSpritesheet', kind: 'method', signature: 'image.newSpritesheet(path, frameSize)', returns: 'Spritesheet', doc: 'Cuts an image into a grid of equally sized frames.\n\nTakes `frameSize` for square frames or `frameWidth, frameHeight`. The first argument may also be an image already loaded, which is how two sheets get cut from one file at different frame sizes.' }
-		]
+		doc: 'Loading textures. The module itself has no methods or properties of its own — its entire surface is the three classes it hands out: `import { Image, Spritesheet, Animation } from "lumen:image"`.',
+		members: []
 	},
 	{
 		name: 'font',
 		source: 'lumen',
-		doc: 'Loading fonts.',
+		doc: 'Fonts. `Font`, the loadable class, is imported from here too: `import font, { Font } from "lumen:font"`.',
 		members: [
-			{ name: 'load', kind: 'method', signature: 'font.load(path, size)', returns: 'Font', doc: 'Loads a TrueType font at a size. `load(size)` uses the built-in font.' },
-			{ name: 'system', kind: 'method', signature: 'font.system([size])', returns: 'Font', doc: 'The built-in font at a size, or the current default when called with nothing.' }
+			{ name: 'system', kind: 'method', signature: 'font.system([size])', returns: 'Font', doc: 'The built-in font at a size, or whatever font `canvas` is currently using when called with nothing.' }
 		]
 	},
 	{
 		name: 'audio',
 		source: 'lumen',
-		doc: 'Sound and music. WAV, OGG and MP3 are supported.',
+		doc: 'Sound and music. WAV, OGG and MP3 are supported. `Source`, the loadable class, is imported from here too: `import audio, { Source } from "lumen:audio"`.',
 		members: [
-			{ name: 'newSource', kind: 'method', signature: "audio.newSource(path, ['static'|'stream'])", returns: 'Source', doc: 'Loads a sound.\n\n`\'static\'` decodes the whole sound up front and can overlap with itself — use it for effects. `\'stream\'` decodes while playing — use it for music.' },
-			{ name: 'play', kind: 'method', signature: 'audio.play(source)', doc: 'Plays a source.' },
-			{ name: 'stop', kind: 'method', signature: 'audio.stop([source])', doc: 'Stops one source, or everything.' },
-			{ name: 'pause', kind: 'method', signature: 'audio.pause()', doc: 'Pauses all audio.' },
-			{ name: 'resume', kind: 'method', signature: 'audio.resume()', doc: 'Resumes all audio.' },
-			{ name: 'setVolume', kind: 'method', signature: 'audio.setVolume(volume)', doc: 'Sets the master volume, 0 to 1.' },
+			{ name: 'play', kind: 'method', signature: 'audio.play(source)', doc: 'Plays a source — shorthand for `source.play()`.' },
+			{ name: 'stop', kind: 'method', signature: 'audio.stop([source])', doc: 'Stops one source, or, called with nothing, every sound and the music together.' },
+			{ name: 'pause', kind: 'method', signature: 'audio.pause()', doc: 'Pauses everything playing.' },
+			{ name: 'resume', kind: 'method', signature: 'audio.resume()', doc: 'Resumes everything paused.' },
+			{ name: 'setVolume', kind: 'method', signature: 'audio.setVolume(volume)', doc: 'Sets the master volume, 0 to 1, scaling every source.' },
 			{ name: 'getVolume', kind: 'method', signature: 'audio.getVolume()', returns: 'Number', doc: 'The master volume, 0 to 1.' }
 		]
 	},
@@ -144,11 +145,11 @@ const MODULES = [
 		source: 'lumen',
 		doc: 'Keyboard state.\n\nEach query takes any number of key names and is true if any of them matches, so one action binds to several keys: `keyboard.isDown(\'left\', \'a\')`. Names are SDL key names, matched case-insensitively; an unrecognised name is an error rather than a silent false.',
 		members: [
-			{ name: 'isDown', kind: 'method', signature: 'keyboard.isDown(key, ...)', returns: 'Boolean', doc: 'Whether any of these keys is held, true on **every frame** it is held.\n\nFor menus and dialogue use `keypressed()` instead, which fires once per physical press.' },
+			{ name: 'isDown', kind: 'method', signature: 'keyboard.isDown(key, ...)', returns: 'Boolean', doc: 'Whether any of these keys is held, true on **every frame** it is held.\n\nFor menus and dialogue use `wasPressed()` instead, which fires once per physical press.' },
 			{ name: 'isUp', kind: 'method', signature: 'keyboard.isUp(key, ...)', returns: 'Boolean', doc: 'Whether any of these keys is not held.' },
 			{ name: 'wasPressed', kind: 'method', signature: 'keyboard.wasPressed(key, ...)', returns: 'Boolean', doc: 'Whether any of these keys went down this frame.' },
 			{ name: 'wasReleased', kind: 'method', signature: 'keyboard.wasReleased(key, ...)', returns: 'Boolean', doc: 'Whether any of these keys came up this frame.' },
-			{ name: 'startTextInput', kind: 'method', signature: 'keyboard.startTextInput()', doc: 'Begins text entry, after which typing raises `textinput()`.' },
+			{ name: 'startTextInput', kind: 'method', signature: 'keyboard.startTextInput()', doc: 'Begins text entry, after which typing raises `textinput()` and the platform on-screen keyboard may appear.' },
 			{ name: 'stopTextInput', kind: 'method', signature: 'keyboard.stopTextInput()', doc: 'Ends text entry.' },
 			{ name: 'isTextInputActive', kind: 'method', signature: 'keyboard.isTextInputActive()', returns: 'Boolean', doc: 'Whether text entry is active.' }
 		]
@@ -172,7 +173,7 @@ const MODULES = [
 			{ name: 'showCursor', kind: 'method', signature: 'mouse.showCursor()', doc: 'Shows the system cursor.' },
 			{ name: 'hideCursor', kind: 'method', signature: 'mouse.hideCursor()', doc: 'Hides the system cursor.' },
 			{ name: 'isVisible', kind: 'method', signature: 'mouse.isVisible()', returns: 'Boolean', doc: 'Whether the system cursor is shown.' },
-			{ name: 'setRelativeMode', kind: 'method', signature: 'mouse.setRelativeMode(enabled)', doc: 'Locks the pointer and reports movement instead of position.' },
+			{ name: 'setRelativeMode', kind: 'method', signature: 'mouse.setRelativeMode(enabled)', doc: 'Hides the pointer and reports movement instead of position.' },
 			{ name: 'setGrabbed', kind: 'method', signature: 'mouse.setGrabbed(grabbed)', doc: 'Confines the pointer to the window.' }
 		]
 	},
@@ -187,7 +188,7 @@ const MODULES = [
 			{ name: 'wasPressed', kind: 'method', signature: 'joystick.wasPressed(index, button)', returns: 'Boolean', doc: 'Whether a button went down this frame.' },
 			{ name: 'wasReleased', kind: 'method', signature: 'joystick.wasReleased(index, button)', returns: 'Boolean', doc: 'Whether a button came up this frame.' },
 			{ name: 'getAxis', kind: 'method', signature: 'joystick.getAxis(index, axis, [deadZone])', returns: 'Number', doc: 'An axis reading. Sticks report -1 to 1 and triggers 0 to 1, with a 0.15 dead zone by default.' },
-			{ name: 'getName', kind: 'method', signature: 'joystick.getName(index)', returns: 'String', doc: 'The controller\'s name.' },
+			{ name: 'getName', kind: 'method', signature: 'joystick.getName(index)', returns: 'String', doc: 'The controller\'s name, or null if it is not connected.' },
 			{ name: 'isConnected', kind: 'method', signature: 'joystick.isConnected(index)', returns: 'Boolean', doc: 'Whether that controller is plugged in.' },
 			{ name: 'vibrate', kind: 'method', signature: 'joystick.vibrate(index, strength, [strength2], [seconds])', doc: 'Rumbles the controller.' }
 		]
@@ -198,14 +199,14 @@ const MODULES = [
 		doc: 'Frame timing.',
 		members: [
 			{ name: 'delta', kind: 'property', signature: 'timer.delta', returns: 'Number', doc: 'How many seconds the previous frame took — the same value `update(dt)` receives.' },
-			{ name: 'averageDelta', kind: 'property', signature: 'timer.averageDelta', returns: 'Number', doc: 'A running average of frame time.' },
+			{ name: 'averageDelta', kind: 'property', signature: 'timer.averageDelta', returns: 'Number', doc: 'A smoothed running average of frame time — what should be shown to a player, rather than the noisier `delta`.' },
 			{ name: 'fps', kind: 'property', signature: 'timer.fps', returns: 'Number', doc: 'The current frame rate.' },
 			{ name: 'time', kind: 'property', signature: 'timer.time', returns: 'Number', doc: 'Seconds since the game started.' },
 			{ name: 'frame', kind: 'property', signature: 'timer.frame', returns: 'Number', doc: 'How many frames have been drawn.' },
 			{ name: 'getDelta', kind: 'method', signature: 'timer.getDelta()', returns: 'Number', doc: 'How many seconds the previous frame took.' },
 			{ name: 'getFps', kind: 'method', signature: 'timer.getFps()', returns: 'Number', doc: 'The current frame rate.' },
 			{ name: 'getTime', kind: 'method', signature: 'timer.getTime()', returns: 'Number', doc: 'Seconds since the game started.' },
-			{ name: 'sleep', kind: 'method', signature: 'timer.sleep(seconds)', doc: 'Pauses. This stalls the frame — rarely what a game loop wants.' }
+			{ name: 'sleep', kind: 'method', signature: 'timer.sleep(seconds)', doc: 'Pauses — stalling the whole frame. Exists for scripts and tools rather than gameplay.' }
 		]
 	},
 	{
@@ -222,35 +223,35 @@ const MODULES = [
 			{ name: 'focused', kind: 'property', signature: 'window.focused', returns: 'Boolean', doc: 'Whether the window has focus.' },
 			{ name: 'setTitle', kind: 'method', signature: 'window.setTitle(title)', doc: 'Sets the window title.' },
 			{ name: 'setMode', kind: 'method', signature: 'window.setMode(w, h, [fullscreen])', doc: 'Sets the window size and fullscreen state together.' },
-			{ name: 'setSize', kind: 'method', signature: 'window.setSize(w, h)', doc: 'Resizes the window.' },
+			{ name: 'setSize', kind: 'method', signature: 'window.setSize(w, h)', doc: 'Resizes the window — an alias for `setMode(w, h)`.' },
 			{ name: 'setLogicalSize', kind: 'method', signature: 'window.setLogicalSize(w, h)', doc: 'Fixes the space the game draws in, letting Lumen scale it to fit the window, keep its proportions, centre it, and letterbox the rest.\n\nThis is what keeps a bigger window from simply showing more of the world. Mouse positions arrive in these coordinates too, so nothing else in the game has to know scaling is happening.' },
 			{ name: 'clearLogicalSize', kind: 'method', signature: 'window.clearLogicalSize()', doc: 'Goes back to drawing in window pixels.' },
 			{ name: 'getLogicalSize', kind: 'method', signature: 'window.getLogicalSize()', doc: 'The logical size, when one is set.' },
 			{ name: 'setPixelPerfect', kind: 'method', signature: 'window.setPixelPerfect(enabled)', doc: 'Rounds the scale down to a whole number, which is what keeps pixel art from developing uneven edges. It costs more of the screen to the bars; worth it for a small canvas, not for a large one.' },
 			{ name: 'setFullscreen', kind: 'method', signature: 'window.setFullscreen(enabled)', doc: 'Enters or leaves fullscreen.' },
-			{ name: 'toggleFullscreen', kind: 'method', signature: 'window.toggleFullscreen()', doc: 'Flips the fullscreen state.' },
+			{ name: 'toggleFullscreen', kind: 'method', signature: 'window.toggleFullscreen()', returns: 'Boolean', doc: 'Flips the fullscreen state and returns the new one.' },
 			{ name: 'setResizable', kind: 'method', signature: 'window.setResizable(enabled)', doc: 'Allows or prevents resizing.' },
 			{ name: 'setBorderless', kind: 'method', signature: 'window.setBorderless(enabled)', doc: 'Removes or restores the window border.' },
 			{ name: 'setVsync', kind: 'method', signature: 'window.setVsync(enabled)', doc: 'Turns vertical sync on or off.' },
-			{ name: 'setIcon', kind: 'method', signature: 'window.setIcon(image)', doc: 'Sets the window icon.' },
+			{ name: 'setIcon', kind: 'method', signature: 'window.setIcon(image)', doc: 'Sets the window icon. `image` must be loaded from a file, not a render target.' },
 			{ name: 'setPosition', kind: 'method', signature: 'window.setPosition(x, y)', doc: 'Moves the window.' },
 			{ name: 'center', kind: 'method', signature: 'window.center()', doc: 'Centres the window on the desktop.' },
 			{ name: 'maximize', kind: 'method', signature: 'window.maximize()', doc: 'Maximises the window.' },
 			{ name: 'minimize', kind: 'method', signature: 'window.minimize()', doc: 'Minimises the window.' },
 			{ name: 'restore', kind: 'method', signature: 'window.restore()', doc: 'Restores a maximised or minimised window.' },
-			{ name: 'getDimensions', kind: 'method', signature: 'window.getDimensions()', doc: 'The real window size, whatever the logical size is.' },
+			{ name: 'getDimensions', kind: 'method', signature: 'window.getDimensions()', doc: 'The real window size, whatever the logical size is set to.' },
 			{ name: 'getDesktopDimensions', kind: 'method', signature: 'window.getDesktopDimensions()', doc: 'The desktop resolution.' }
 		]
 	},
 	{
 		name: 'filesystem',
 		source: 'lumen',
-		doc: "Saved games, in the player's own data directory rather than next to the program — a game installed read-only cannot write to its own folder.\n\nSaves land in `~/.local/share/lumen/<identity>` on Linux, `~/Library/Application Support/lumen/<identity>` on macOS, and `%AppData%\\lumen\\<identity>` on Windows. Save paths cannot escape the save directory.",
+		doc: "Saved games, in the player's own data directory rather than next to the program — a game installed read-only cannot write to its own folder. Distinct from Ghost's own `file` module, which reads and writes relative to the script.\n\nSaves land in `~/.local/share/lumen/<identity>` on Linux, `~/Library/Application Support/lumen/<identity>` on macOS, and `%AppData%\\lumen\\<identity>` on Windows. Save paths cannot escape the save directory.",
 		members: [
 			{ name: 'setIdentity', kind: 'method', signature: 'filesystem.setIdentity(name)', doc: 'Names the game\'s save directory. Call once, in `load()`.' },
 			{ name: 'getSaveDirectory', kind: 'method', signature: 'filesystem.getSaveDirectory()', returns: 'String', doc: 'The full path saves are written to.' },
 			{ name: 'read', kind: 'method', signature: 'filesystem.read(name)', returns: 'String', doc: 'Reads a saved file, returning **null** when it does not exist — so "no save yet" is an ordinary case rather than an error.' },
-			{ name: 'write', kind: 'method', signature: 'filesystem.write(name, contents)', doc: 'Writes a saved file, replacing what was there.' },
+			{ name: 'write', kind: 'method', signature: 'filesystem.write(name, contents)', doc: 'Writes a saved file, replacing what was there, creating parent directories as needed.' },
 			{ name: 'append', kind: 'method', signature: 'filesystem.append(name, contents)', doc: 'Appends to a saved file.' },
 			{ name: 'exists', kind: 'method', signature: 'filesystem.exists(name)', returns: 'Boolean', doc: 'Whether a saved file exists.' },
 			{ name: 'remove', kind: 'method', signature: 'filesystem.remove(name)', doc: 'Deletes a saved file.' },
@@ -268,8 +269,8 @@ const MODULES = [
 			{ name: 'processorCount', kind: 'property', signature: 'system.processorCount', returns: 'Number', doc: 'How many logical processors the machine has.' },
 			{ name: 'getClipboardText', kind: 'method', signature: 'system.getClipboardText()', returns: 'String', doc: 'The clipboard contents.' },
 			{ name: 'setClipboardText', kind: 'method', signature: 'system.setClipboardText(text)', doc: 'Puts text on the clipboard.' },
-			{ name: 'openUrl', kind: 'method', signature: 'system.openUrl(url)', doc: 'Opens a URL in the default browser. http and https only.' },
-			{ name: 'getPowerInfo', kind: 'method', signature: 'system.getPowerInfo()', doc: 'Battery state and charge.' }
+			{ name: 'openUrl', kind: 'method', signature: 'system.openUrl(url)', doc: 'Opens a URL in the default browser. http and https only — rejected otherwise, so a string built at runtime cannot reach the shell as something else.' },
+			{ name: 'getPowerInfo', kind: 'method', signature: 'system.getPowerInfo()', doc: 'Battery state and charge, as `[state, percent, seconds]`.' }
 		]
 	},
 	{
@@ -285,61 +286,32 @@ const MODULES = [
 	}
 ];
 
-/**
- * What Lumen adds to Ghost's own `math` module. These are merged into it
- * rather than exposed separately, matching how the engine registers them.
- *
- * @type {Member[]}
- */
-const MATH_EXTENSIONS = [
-	{ name: 'floor', kind: 'method', signature: 'math.floor(n)', returns: 'Number', doc: 'The largest whole number no greater than `n`.', source: 'lumen' },
-	{ name: 'ceil', kind: 'method', signature: 'math.ceil(n)', returns: 'Number', doc: 'The smallest whole number no less than `n`.', source: 'lumen' },
-	{ name: 'round', kind: 'method', signature: 'math.round(n)', returns: 'Number', doc: '`n` rounded to the nearest whole number.', source: 'lumen' },
-	{ name: 'sqrt', kind: 'method', signature: 'math.sqrt(n)', returns: 'Number', doc: 'The square root of `n`.', source: 'lumen' },
-	{ name: 'pow', kind: 'method', signature: 'math.pow(base, exponent)', returns: 'Number', doc: '`base` raised to `exponent`.', source: 'lumen' },
-	{ name: 'exp', kind: 'method', signature: 'math.exp(n)', returns: 'Number', doc: 'e raised to `n`.', source: 'lumen' },
-	{ name: 'log', kind: 'method', signature: 'math.log(n)', returns: 'Number', doc: 'The natural logarithm of `n`.', source: 'lumen' },
-	{ name: 'sign', kind: 'method', signature: 'math.sign(n)', returns: 'Number', doc: '-1, 0 or 1, according to the sign of `n`.', source: 'lumen' },
-	{ name: 'asin', kind: 'method', signature: 'math.asin(n)', returns: 'Number', doc: 'The arcsine of `n`, in radians.', source: 'lumen' },
-	{ name: 'acos', kind: 'method', signature: 'math.acos(n)', returns: 'Number', doc: 'The arccosine of `n`, in radians.', source: 'lumen' },
-	{ name: 'atan', kind: 'method', signature: 'math.atan(n)', returns: 'Number', doc: 'The arctangent of `n`, in radians.', source: 'lumen' },
-	{ name: 'atan2', kind: 'method', signature: 'math.atan2(y, x)', returns: 'Number', doc: 'The angle of the vector `(x, y)`, in radians, with the quadrant resolved.', source: 'lumen' },
-	{ name: 'degrees', kind: 'method', signature: 'math.degrees(radians)', returns: 'Number', doc: 'Radians converted to degrees.', source: 'lumen' },
-	{ name: 'radians', kind: 'method', signature: 'math.radians(degrees)', returns: 'Number', doc: 'Degrees converted to radians.', source: 'lumen' },
-	{ name: 'clamp', kind: 'method', signature: 'math.clamp(value, low, high)', returns: 'Number', doc: '`value` held between `low` and `high`.', source: 'lumen' },
-	{ name: 'lerp', kind: 'method', signature: 'math.lerp(from, to, amount)', returns: 'Number', doc: 'A point `amount` of the way from `from` to `to`.', source: 'lumen' },
-	{ name: 'distance', kind: 'method', signature: 'math.distance(x1, y1, x2, y2)', returns: 'Number', doc: 'The distance between two points.', source: 'lumen' },
-	{ name: 'angle', kind: 'method', signature: 'math.angle(x1, y1, x2, y2)', returns: 'Number', doc: 'The angle from one point to another, in radians.', source: 'lumen' },
-	{ name: 'random', kind: 'method', signature: 'math.random([low], [high])', returns: 'Number', doc: 'A random number: 0 to 1 with no arguments, 1 to `n` with one, `low` to `high` with two.\n\nDraws on a generator kept separate from the global one, so seeding it for reproducible level generation cannot be disturbed by anything else.', source: 'lumen' },
-	{ name: 'randomSeed', kind: 'method', signature: 'math.randomSeed(n)', doc: 'Seeds the generator, making the sequence that follows repeatable.', source: 'lumen' },
-	{ name: 'noise', kind: 'method', signature: 'math.noise(x, [y])', returns: 'Number', doc: 'Smoothly varying noise — for terrain, clouds and other things that should look organic rather than random.', source: 'lumen' }
-];
-
 /** @type {ObjectType[]} */
 const TYPES = [
 	{
 		name: 'Image',
 		source: 'lumen',
-		doc: 'A loaded texture. Returned by `image.load()`.',
+		module: 'image',
+		doc: 'A loaded texture. `new Image(path)`, resolved against the game\'s directory unless absolute — imported with `import { Image } from "lumen:image"`.',
 		methods: [
 			{ name: 'draw', kind: 'method', signature: 'draw(x, y, [rotation, sx, sy, ox, oy])', doc: 'Draws the image.\n\n' + DRAW_TAIL },
 			{ name: 'drawQuad', kind: 'method', signature: 'drawQuad(quad, x, y, [rotation, sx, sy, ox, oy])', doc: 'Draws one rectangle of the image.\n\n' + DRAW_TAIL },
-			{ name: 'clip', kind: 'method', signature: 'clip(x, y, w, h)', returns: 'Image', doc: 'A lightweight view onto part of the image — how one spritesheet becomes many sprites. Also takes `clip(x, y, size)` for a square.' },
+			{ name: 'clip', kind: 'method', signature: 'clip(x, y, w, h)', returns: 'Image', doc: 'A lightweight, cached view onto part of the image — how one spritesheet becomes many sprites. Also takes `clip(x, y, size)` for a square.' },
 			{ name: 'getWidth', kind: 'method', signature: 'getWidth()', returns: 'Number', doc: 'The image width in pixels.' },
 			{ name: 'getHeight', kind: 'method', signature: 'getHeight()', returns: 'Number', doc: 'The image height in pixels.' },
 			{ name: 'getDimensions', kind: 'method', signature: 'getDimensions()', doc: 'The image width and height.' },
-			{ name: 'getPixel', kind: 'method', signature: 'getPixel(x, y)', returns: 'Color', doc: 'Reads a pixel from the source image, which lets collision or spawn data be baked into a map image.' },
-			{ name: 'setFilter', kind: 'method', signature: "setFilter('nearest'|'linear')", doc: 'How the image is sampled when scaled. `\'nearest\'` for pixel art.' },
+			{ name: 'getPixel', kind: 'method', signature: 'getPixel(x, y)', returns: 'Color', doc: 'Reads a pixel from the source image, which lets collision or spawn data be baked into a map image. Errors on an image with no source surface — a render target, say.' },
+			{ name: 'setFilter', kind: 'method', signature: "setFilter('nearest'|'linear')", doc: 'How the image is sampled when scaled. `\'nearest\'` (the default) for pixel art.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'A description of the image.' }
 		]
 	},
 	{
 		name: 'Spritesheet',
 		source: 'lumen',
-		doc: 'One image cut into a grid of equally sized frames, numbered left to right and top to bottom **from zero**. The quads are built once, when the sheet is made, so drawing a frame never allocates.',
+		module: 'image',
+		doc: '`new Spritesheet(source, frameWidth, [frameHeight])` — `source` may be a path string or an already-loaded `Image`, and `frameHeight` defaults to `frameWidth`. One image cut into a grid of equally sized frames, numbered left to right and top to bottom **from zero**. The quads are built once, when the sheet is made, so drawing a frame never allocates. Imported with `import { Spritesheet } from "lumen:image"`.',
 		methods: [
 			{ name: 'draw', kind: 'method', signature: 'draw(frame, x, y, [rotation, sx, sy, ox, oy])', doc: 'Draws one frame.\n\n' + DRAW_TAIL },
-			{ name: 'newAnimation', kind: 'method', signature: "newAnimation(frames, secondsPerFrame, ['loop'|'once'|'pingpong'])", returns: 'Animation', doc: 'A sequence of this sheet\'s frames played against a clock.\n\n```ghost\nwalk = sheet.newAnimation([4, 5, 6, 7], 0.16)\n```' },
 			{ name: 'getQuad', kind: 'method', signature: 'getQuad(frame)', returns: 'Quad', doc: 'The quad for one frame.' },
 			{ name: 'getImage', kind: 'method', signature: 'getImage()', returns: 'Image', doc: 'The image the sheet was cut from.' },
 			{ name: 'getCount', kind: 'method', signature: 'getCount()', returns: 'Number', doc: 'How many frames the sheet holds.' },
@@ -354,24 +326,25 @@ const TYPES = [
 	{
 		name: 'Animation',
 		source: 'lumen',
-		doc: "A sequence of a spritesheet's frames played against a clock.\n\n**The clock is time, not frames drawn.** `secondsPerFrame` is what it says, so a walk cycle runs at the same speed on a machine managing 30 FPS as on one managing 144.\n\nEach animation carries its own playhead, so two characters showing the same walk cycle need one each — `clone()` is the cheap way to get one.",
+		module: 'image',
+		doc: "`new Animation(sheet, frames, duration, ['loop'|'once'|'pingpong'])` — a sequence of a spritesheet's frames played against a clock. Imported with `import { Animation } from \"lumen:image\"`.\n\n**The clock is time, not frames drawn.** `duration` (seconds per frame) is what it says, so a walk cycle runs at the same speed on a machine managing 30 FPS as on one managing 144.\n\nEach animation carries its own playhead, so two characters showing the same walk cycle need one each — `clone()` is the cheap way to get one.",
 		methods: [
 			{ name: 'update', kind: 'method', signature: 'update([dt])', doc: 'Advances the playhead. Called with nothing it uses the last frame\'s time.' },
 			{ name: 'draw', kind: 'method', signature: 'draw(x, y, [rotation, sx, sy, ox, oy])', doc: 'Draws the current frame.\n\n' + DRAW_TAIL },
 			{ name: 'play', kind: 'method', signature: 'play()', doc: 'Starts playing from the beginning.' },
 			{ name: 'pause', kind: 'method', signature: 'pause()', doc: 'Holds the current frame.' },
 			{ name: 'resume', kind: 'method', signature: 'resume()', doc: 'Continues from where it was paused.' },
-			{ name: 'stop', kind: 'method', signature: 'stop()', doc: 'Stops and rewinds.' },
-			{ name: 'reset', kind: 'method', signature: 'reset()', doc: 'Returns the playhead to the start.' },
+			{ name: 'stop', kind: 'method', signature: 'stop()', doc: 'Stops and resets the elapsed time to zero.' },
+			{ name: 'reset', kind: 'method', signature: 'reset()', doc: 'Returns the playhead to the start and resumes.' },
 			{ name: 'seek', kind: 'method', signature: 'seek(seconds)', doc: 'Moves the playhead to a point in time — how a game that keeps its own clock drives an animation without calling `update()`.' },
-			{ name: 'clone', kind: 'method', signature: 'clone()', returns: 'Animation', doc: 'A copy with its own playhead.' },
+			{ name: 'clone', kind: 'method', signature: 'clone()', returns: 'Animation', doc: 'A copy with its own playhead, sharing the sheet and frame list.' },
 			{ name: 'isPlaying', kind: 'method', signature: 'isPlaying()', returns: 'Boolean', doc: 'Whether it is playing.' },
 			{ name: 'isPaused', kind: 'method', signature: 'isPaused()', returns: 'Boolean', doc: 'Whether it is paused.' },
 			{ name: 'isFinished', kind: 'method', signature: 'isFinished()', returns: 'Boolean', doc: 'Whether a `\'once\'` animation has reached its last frame. `\'loop\'` and `\'pingpong\'` never finish.' },
-			{ name: 'getFrame', kind: 'method', signature: 'getFrame()', returns: 'Number', doc: 'The frame currently showing.' },
+			{ name: 'getFrame', kind: 'method', signature: 'getFrame()', returns: 'Number', doc: 'The sheet frame currently showing.' },
 			{ name: 'getFrameCount', kind: 'method', signature: 'getFrameCount()', returns: 'Number', doc: 'How many frames the sequence holds.' },
 			{ name: 'getElapsed', kind: 'method', signature: 'getElapsed()', returns: 'Number', doc: 'How far the playhead has travelled, in seconds.' },
-			{ name: 'getLength', kind: 'method', signature: 'getLength()', returns: 'Number', doc: 'The sequence\'s total length in seconds.' },
+			{ name: 'getLength', kind: 'method', signature: 'getLength()', returns: 'Number', doc: 'The sequence\'s total length in seconds for one full pass — a ping-pong animation counts the return trip.' },
 			{ name: 'getSheet', kind: 'method', signature: 'getSheet()', returns: 'Spritesheet', doc: 'The spritesheet the frames come from.' },
 			{ name: 'getDuration', kind: 'method', signature: 'getDuration()', returns: 'Number', doc: 'Seconds per frame.' },
 			{ name: 'setDuration', kind: 'method', signature: 'setDuration(seconds)', doc: 'Sets seconds per frame. A duration of `0` holds the first frame, which is how a still pose is written.' },
@@ -385,20 +358,22 @@ const TYPES = [
 	{
 		name: 'Quad',
 		source: 'lumen',
-		doc: 'A rectangle of a texture. Building one per animation frame up front and reusing it beats allocating one per draw.',
+		module: 'canvas',
+		doc: '`new Quad(x, y, w, h)` — a rectangle of a texture. Building one per animation frame up front and reusing it beats allocating one per draw. Imported with `import { Quad } from "lumen:canvas"`.',
 		methods: [
 			{ name: 'getX', kind: 'method', signature: 'getX()', returns: 'Number', doc: 'The rectangle\'s x position within the texture.' },
 			{ name: 'getY', kind: 'method', signature: 'getY()', returns: 'Number', doc: 'The rectangle\'s y position within the texture.' },
 			{ name: 'getWidth', kind: 'method', signature: 'getWidth()', returns: 'Number', doc: 'The rectangle\'s width.' },
 			{ name: 'getHeight', kind: 'method', signature: 'getHeight()', returns: 'Number', doc: 'The rectangle\'s height.' },
-			{ name: 'setViewport', kind: 'method', signature: 'setViewport(x, y, w, h)', doc: 'Moves the rectangle within the texture.' },
+			{ name: 'setViewport', kind: 'method', signature: 'setViewport(x, y, w, h)', doc: 'Moves the rectangle within the texture, in place.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'A description of the quad.' }
 		]
 	},
 	{
 		name: 'Font',
 		source: 'lumen',
-		doc: 'A loaded font.\n\nRendered strings are cached, so drawing the same text every frame costs almost nothing; text that changes every frame is evicted automatically.',
+		module: 'font',
+		doc: '`new Font(path, size)` — a loaded TrueType font at a pixel size. Called with one argument, `Font(size)`, it is shorthand for `font.system(size)`. Imported with `import { Font } from "lumen:font"`.\n\nRendered strings are cached, so drawing the same text every frame costs almost nothing; text that changes every frame is evicted automatically.',
 		methods: [
 			{ name: 'print', kind: 'method', signature: 'print(text, x, y, [rotation, sx, sy, ox, oy])', doc: 'Draws a line of text in this font.' },
 			{ name: 'printf', kind: 'method', signature: "printf(text, x, y, limit, ['left'|'center'|'right'], [rotation, sx, sy, ox, oy])", doc: 'Draws text wrapped to `limit` pixels wide.' },
@@ -408,8 +383,8 @@ const TYPES = [
 			{ name: 'setLineHeight', kind: 'method', signature: 'setLineHeight(n)', doc: 'Sets the distance between baselines.' },
 			{ name: 'getAscent', kind: 'method', signature: 'getAscent()', returns: 'Number', doc: 'How far the font rises above the baseline.' },
 			{ name: 'getDescent', kind: 'method', signature: 'getDescent()', returns: 'Number', doc: 'How far the font drops below the baseline.' },
-			{ name: 'getBaseline', kind: 'method', signature: 'getBaseline()', returns: 'Number', doc: 'The baseline offset.' },
-			{ name: 'getWrap', kind: 'method', signature: 'getWrap(text, limit)', returns: 'List', doc: 'The lines `text` would wrap into at `limit` pixels wide.' },
+			{ name: 'getBaseline', kind: 'method', signature: 'getBaseline()', returns: 'Number', doc: 'The baseline offset — the same value as `getAscent()`.' },
+			{ name: 'getWrap', kind: 'method', signature: 'getWrap(text, limit)', returns: 'List', doc: 'The widest line\'s width and the lines `text` would wrap into at `limit` pixels wide.' },
 			{ name: 'getSize', kind: 'method', signature: 'getSize()', returns: 'Number', doc: 'The size the font was loaded at.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'A description of the font.' }
 		]
@@ -417,13 +392,13 @@ const TYPES = [
 	{
 		name: 'Color',
 		source: 'lumen',
-		doc: 'A colour.',
+		doc: 'A colour, made with `color.rgb()`, `color.hex()`, `color.hsl()`, or read off the named palette — not a `new`-able class itself.',
 		methods: [
 			{ name: 'getRed', kind: 'method', signature: 'getRed()', returns: 'Number', doc: 'The red component, 0–255.' },
 			{ name: 'getGreen', kind: 'method', signature: 'getGreen()', returns: 'Number', doc: 'The green component, 0–255.' },
 			{ name: 'getBlue', kind: 'method', signature: 'getBlue()', returns: 'Number', doc: 'The blue component, 0–255.' },
 			{ name: 'getAlpha', kind: 'method', signature: 'getAlpha()', returns: 'Number', doc: 'The alpha component, 0–255.' },
-			{ name: 'toHex', kind: 'method', signature: 'toHex()', returns: 'String', doc: 'The colour as a hex string.' },
+			{ name: 'toHex', kind: 'method', signature: 'toHex()', returns: 'String', doc: 'The colour as a `#rrggbbaa` hex string.' },
 			{ name: 'withAlpha', kind: 'method', signature: 'withAlpha(alpha)', returns: 'Color', doc: 'The same colour at a different opacity, 0 to 1.' },
 			{ name: 'lerp', kind: 'method', signature: 'lerp(other, amount)', returns: 'Color', doc: 'A colour `amount` of the way towards `other`.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'A description of the colour.' }
@@ -432,7 +407,8 @@ const TYPES = [
 	{
 		name: 'Target',
 		source: 'lumen',
-		doc: 'An off-screen surface. Draw into it with `canvas.setTarget(target)`, return to the window with `canvas.setTarget()`, then draw it like any image.',
+		module: 'canvas',
+		doc: '`new Target(width, height)` — an off-screen surface. Draw into it with `canvas.setTarget(target)`, return to the window with `canvas.setTarget()`, then draw it like any image. Imported with `import { Target } from "lumen:canvas"`.',
 		methods: [
 			{ name: 'draw', kind: 'method', signature: 'draw(x, y, [rotation, sx, sy, ox, oy])', doc: 'Draws the target.\n\n' + DRAW_TAIL },
 			{ name: 'getWidth', kind: 'method', signature: 'getWidth()', returns: 'Number', doc: 'The target\'s width.' },
@@ -444,7 +420,8 @@ const TYPES = [
 	{
 		name: 'Source',
 		source: 'lumen',
-		doc: 'A loaded sound.\n\nA sound that cannot find a free channel is dropped rather than raising: in a loud moment the least important effect should go missing, not the frame that triggered it.',
+		module: 'audio',
+		doc: "`new Source(path, ['static'|'stream'])` — a loaded sound, default `'static'`. `'static'` decodes the whole sound up front and can overlap with itself — use it for effects. `'stream'` decodes while playing — use it for music. Imported with `import { Source } from \"lumen:audio\"`.\n\nA sound that cannot find a free channel is dropped rather than raising: in a loud moment the least important effect should go missing, not the frame that triggered it.",
 		methods: [
 			{ name: 'play', kind: 'method', signature: 'play()', doc: 'Plays the sound.' },
 			{ name: 'stop', kind: 'method', signature: 'stop()', doc: 'Stops the sound.' },
@@ -458,10 +435,10 @@ const TYPES = [
 			{ name: 'getVolume', kind: 'method', signature: 'getVolume()', returns: 'Number', doc: 'This sound\'s volume, 0 to 1.' },
 			{ name: 'fadeIn', kind: 'method', signature: 'fadeIn(seconds)', doc: 'Plays, rising to full volume over `seconds`.' },
 			{ name: 'fadeOut', kind: 'method', signature: 'fadeOut(seconds)', doc: 'Falls silent over `seconds`, then stops.' },
-			{ name: 'clone', kind: 'method', signature: 'clone()', returns: 'Source', doc: 'A copy that plays independently.' },
+			{ name: 'clone', kind: 'method', signature: 'clone()', returns: 'Source', doc: 'A copy that plays independently, sharing the decoded data. `\'static\'` sources only.' },
 			{ name: 'setPanning', kind: 'method', signature: 'setPanning(left, right)', doc: 'A volume per speaker, each 0 to 1, so `setPanning(1, 0)` is hard left. `\'static\'` sources only.' },
 			{ name: 'setPosition', kind: 'method', signature: 'setPosition(angle, distance)', doc: 'Places a sound in the world: an angle in degrees where 0 is ahead and 90 is to the right, and a distance from 0 to 1. `\'static\'` sources only.' },
-			{ name: 'clearEffects', kind: 'method', signature: 'clearEffects()', doc: 'Removes panning and positioning.' },
+			{ name: 'clearEffects', kind: 'method', signature: 'clearEffects()', doc: 'Removes panning and positioning, back to centred stereo.' },
 			{ name: 'toString', kind: 'method', signature: 'toString()', returns: 'String', doc: 'A description of the sound.' }
 		]
 	}
@@ -469,7 +446,9 @@ const TYPES = [
 
 /**
  * Functions the engine calls by name. Every one is optional; a game defines
- * the ones it needs.
+ * the ones it needs. These are plain top-level declarations in the entry
+ * file's global scope — not module members — so they need no import at all,
+ * unaffected by everything else that moved behind one.
  *
  * @type {Callback[]}
  */
@@ -477,18 +456,18 @@ const CALLBACKS = [
 	{ name: 'load', source: 'lumen', signature: 'function load()', doc: 'Runs once, before the first frame. Load assets and build initial state here.\n\nIf `load()` raises an error Lumen reports it and exits, rather than running a game whose state was never finished.' },
 	{ name: 'update', source: 'lumen', signature: 'function update(dt)', doc: 'Runs every frame. `dt` is how many seconds the previous frame took.\n\n**Scale anything that moves by it.** A speed written as pixels-per-frame changes with the frame rate; a speed written as pixels-per-second does not. `dt` is capped at 0.25s, so a frame that stalls cannot teleport everything.' },
 	{ name: 'draw', source: 'lumen', signature: 'function draw()', doc: 'Runs every frame, after `update()`. Draw the game here and change no state.' },
-	{ name: 'keypressed', source: 'lumen', signature: 'function keypressed(key, isRepeat)', doc: 'A key went down.\n\nUse this rather than `keyboard.isDown()` for menus and dialogue: it fires once per physical press, where `isDown` is true on every frame the key is held.' },
+	{ name: 'keypressed', source: 'lumen', signature: 'function keypressed(key, isRepeat)', doc: 'A key went down. `key` is an SDL scancode name; `isRepeat` is true for a held key\'s repeat events.\n\nUse this rather than `keyboard.isDown()` for menus and dialogue: it fires once per physical press, where `isDown` is true on every frame the key is held.' },
 	{ name: 'keyreleased', source: 'lumen', signature: 'function keyreleased(key)', doc: 'A key came up.' },
 	{ name: 'textinput', source: 'lumen', signature: 'function textinput(text)', doc: 'Text was typed, between `keyboard.startTextInput()` and `keyboard.stopTextInput()`.' },
-	{ name: 'mousepressed', source: 'lumen', signature: 'function mousepressed(x, y, button, clicks)', doc: 'A mouse button went down.' },
+	{ name: 'mousepressed', source: 'lumen', signature: 'function mousepressed(x, y, button, clicks)', doc: 'A mouse button went down. `clicks` counts a double-click.' },
 	{ name: 'mousereleased', source: 'lumen', signature: 'function mousereleased(x, y, button)', doc: 'A mouse button came up.' },
-	{ name: 'mousemoved', source: 'lumen', signature: 'function mousemoved(x, y, dx, dy)', doc: 'The pointer moved. `dx` and `dy` are how far it moved since the last report.' },
-	{ name: 'wheelmoved', source: 'lumen', signature: 'function wheelmoved(x, y)', doc: 'The wheel turned.' },
-	{ name: 'resize', source: 'lumen', signature: 'function resize(width, height)', doc: 'The window was resized.' },
+	{ name: 'mousemoved', source: 'lumen', signature: 'function mousemoved(x, y, dx, dy)', doc: 'The pointer moved. `dx` and `dy` are how far it moved since the last report, already scaled to match `x`/`y`.' },
+	{ name: 'wheelmoved', source: 'lumen', signature: 'function wheelmoved(x, y)', doc: 'The wheel turned, on either axis.' },
+	{ name: 'resize', source: 'lumen', signature: 'function resize(width, height)', doc: 'The window was resized, to its real size — not the logical size, if one is set.' },
 	{ name: 'focus', source: 'lumen', signature: 'function focus(hasFocus)', doc: 'The window gained or lost focus.' },
-	{ name: 'joystickadded', source: 'lumen', signature: 'function joystickadded(count)', doc: 'A controller was plugged in.' },
-	{ name: 'joystickremoved', source: 'lumen', signature: 'function joystickremoved(count)', doc: 'A controller was unplugged.' },
+	{ name: 'joystickadded', source: 'lumen', signature: 'function joystickadded(count)', doc: 'A controller was plugged in. `count` is the total now connected, not the new controller\'s index.' },
+	{ name: 'joystickremoved', source: 'lumen', signature: 'function joystickremoved(count)', doc: 'A controller was unplugged. `count` is the total now connected.' },
 	{ name: 'quit', source: 'lumen', signature: 'function quit()', doc: 'The window was closed. Return `true` to cancel and keep the game running.' }
 ];
 
-module.exports = { MODULES, MATH_EXTENSIONS, TYPES, CALLBACKS };
+module.exports = { MODULES, TYPES, CALLBACKS };

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -28,6 +28,12 @@ export interface Module {
 	source: Source;
 	doc: string;
 	members: Member[];
+	/**
+	 * Reachable without an `import` at all. True only for `console` — every
+	 * other module, in both Ghost and Lumen, has to be pulled in with
+	 * `import ... from "ghost:name"` or `"lumen:name"`.
+	 */
+	global?: boolean;
 }
 
 export interface ObjectType {
@@ -35,6 +41,13 @@ export interface ObjectType {
 	source: Source;
 	doc: string;
 	methods: Member[];
+	/**
+	 * The module a class is `new`-able from — set only for a type reached via
+	 * `import { Name } from "<source>:<module>"` (Lumen's Image, Spritesheet,
+	 * Animation, Source, Font, Target, Quad). Unset for a core value type
+	 * (String, List, Number, Map, Date), which needs no import at all.
+	 */
+	module?: string;
 }
 
 export interface GlobalFunction {
@@ -43,6 +56,8 @@ export interface GlobalFunction {
 	signature: string;
 	doc: string;
 	returns?: string;
+	/** Reachable without an `import`. True only for `type`. */
+	global?: boolean;
 }
 
 export interface Callback {

--- a/src/extension.js
+++ b/src/extension.js
@@ -53,7 +53,7 @@ function activate(context) {
 		vscode.languages.registerCompletionItemProvider(
 			SELECTOR,
 			new GhostCompletionProvider(getApi),
-			'.'
+			'.', '"', "'", '{', ':'
 		),
 
 		vscode.languages.registerHoverProvider(SELECTOR, new GhostHoverProvider(getApi)),

--- a/src/providers/completion.js
+++ b/src/providers/completion.js
@@ -45,7 +45,113 @@ class GhostCompletionProvider {
 			return this.memberCompletions(model, document, position, stripped, dotIndex);
 		}
 
+		// Writing an `import` needs its own completions - a module's members
+		// are not offered here at all, only what the statement itself takes:
+		// which module, and (inside `{ }`) which of that module's names.
+		if (/^\s*import\b/.test(stripped)) {
+			const items = this.importStatementCompletions(model, document, position, stripped);
+
+			if (items) {
+				return items;
+			}
+		}
+
 		return this.globalCompletions(model, document, position);
+	}
+
+	/**
+	 * Completions for the `import` statement itself.
+	 *
+	 * Almost everything in the standard library and in Lumen now has to be
+	 * imported before it can be used at all, so writing the import is the
+	 * first thing a script does with a module - this is where naming it
+	 * should be easiest, not an afterthought.
+	 *
+	 * @param {Api} model
+	 * @param {vscode.TextDocument} document
+	 * @param {vscode.Position} position
+	 * @param {string} strippedUpToCursor
+	 * @returns {vscode.CompletionItem[] | undefined} undefined defers to the caller's normal completion
+	 */
+	importStatementCompletions(model, document, position, strippedUpToCursor) {
+		const fullLine = document.lineAt(position.line).text;
+		const rawUpToCursor = fullLine.slice(0, position.character);
+
+		// Typing the scheme name inside an already-open string: `import
+		// "ghost:` or `import "lumen:ca`.
+		const schemeMatch = /import\s+["']([A-Za-z][A-Za-z0-9+.-]+):([A-Za-z0-9_]*)$/.exec(rawUpToCursor);
+
+		if (schemeMatch) {
+			const [, scheme] = schemeMatch;
+
+			return model.modules
+				.filter((module) => module.source === scheme && !module.global)
+				.map((module) => {
+					const item = new vscode.CompletionItem(module.name, vscode.CompletionItemKind.Module);
+
+					item.detail = (module.source === 'lumen' ? 'Lumen' : 'Ghost') + ' module';
+					item.documentation = new vscode.MarkdownString(module.doc);
+
+					return item;
+				});
+		}
+
+		// Inside `{ ... }` of a `from` clause. The module the names come from is
+		// written *after* the braces (`import { a, b } from "scheme:name"`), so
+		// this only resolves when it is already there later on the same line -
+		// editing an existing import to pull in one more name, typically.
+		const braceOpen = strippedUpToCursor.lastIndexOf('{');
+		const braceCloseBeforeCursor = strippedUpToCursor.lastIndexOf('}');
+
+		if (braceOpen !== -1 && braceOpen > braceCloseBeforeCursor) {
+			const afterCursor = fullLine.slice(position.character);
+			const fromMatch = /^[^{}]*\}\s*from\s+["']([A-Za-z][A-Za-z0-9+.-]+):([A-Za-z0-9_]+)["']/.exec(afterCursor);
+
+			if (!fromMatch) {
+				return [];
+			}
+
+			const [, scheme, moduleName] = fromMatch;
+			const module = model.moduleByName.get(moduleName);
+			const already = new Set(strippedUpToCursor.slice(braceOpen + 1).match(/[A-Za-z_]\w*/g) || []);
+			/** @type {vscode.CompletionItem[]} */
+			const items = [];
+
+			for (const member of (module ? module.members : [])) {
+				if (!already.has(member.name)) {
+					items.push(this.memberItem(member, moduleName, /** @type {import('../api/types').Source} */ (scheme)));
+				}
+			}
+
+			for (const type of api.classesOf(model, /** @type {import('../api/types').Source} */ (scheme), moduleName)) {
+				if (!already.has(type.name)) {
+					items.push(this.classItem(type));
+				}
+			}
+
+			return items;
+		}
+
+		// Right after `import `, with at most a bare partial name typed and
+		// nothing else on the line - offer every importable module, inserting
+		// the whole `"scheme:name"` path.
+		if (/^\s*import\s+[A-Za-z]*$/.test(strippedUpToCursor)) {
+			return model.modules
+				.filter((module) => !module.global)
+				.map((module) => {
+					const item = new vscode.CompletionItem(module.name, vscode.CompletionItemKind.Module);
+
+					item.detail = (module.source === 'lumen' ? 'Lumen' : 'Ghost') + ' module';
+					item.documentation = new vscode.MarkdownString(module.doc);
+					item.insertText = new vscode.SnippetString('"' + module.source + ':' + module.name + '"');
+					item.filterText = module.name;
+					item.sortText = '0' + module.name;
+
+					return item;
+				});
+		}
+
+		return undefined;
 	}
 
 	/**
@@ -68,7 +174,8 @@ class GhostCompletionProvider {
 
 		if (chain) {
 			const known = analyzer.inferTypes(model, text);
-			const resolved = analyzer.resolveChain(model, chain, known);
+			const imports = analyzer.resolveImports(model, text);
+			const resolved = analyzer.resolveChain(model, chain, known, imports);
 
 			if (resolved && resolved.kind === 'module') {
 				const module = model.moduleByName.get(resolved.name);
@@ -192,6 +299,20 @@ class GhostCompletionProvider {
 	}
 
 	/**
+	 * @param {import('../api/types').ObjectType} type
+	 * @returns {vscode.CompletionItem}
+	 */
+	classItem(type) {
+		const item = new vscode.CompletionItem(type.name, vscode.CompletionItemKind.Class);
+
+		item.detail = 'new ' + type.name + '(...)';
+		item.documentation = documentationFor(type, type.source);
+		item.insertText = new vscode.SnippetString(type.name + '($0)');
+
+		return item;
+	}
+
+	/**
 	 * @param {Api} model
 	 * @param {vscode.TextDocument} document
 	 * @param {vscode.Position} position
@@ -207,7 +328,14 @@ class GhostCompletionProvider {
 			items.push(item);
 		}
 
+		// Only `console` and `type` are reachable without an `import` — every
+		// other module and function needs one first, which is what
+		// `importedCompletions` and `importStatementCompletions` are for.
 		for (const module of model.modules) {
+			if (!module.global) {
+				continue;
+			}
+
 			const item = new vscode.CompletionItem(module.name, vscode.CompletionItemKind.Module);
 			item.detail = module.source === 'lumen' ? 'Lumen module' : 'Ghost module';
 			item.documentation = new vscode.MarkdownString(module.doc);
@@ -216,6 +344,10 @@ class GhostCompletionProvider {
 		}
 
 		for (const fn of model.functions) {
+			if (!fn.global) {
+				continue;
+			}
+
 			const item = new vscode.CompletionItem(fn.name, vscode.CompletionItemKind.Function);
 			item.detail = fn.signature;
 			item.documentation = documentationFor(fn, fn.source);
@@ -225,7 +357,85 @@ class GhostCompletionProvider {
 		}
 
 		items.push(...this.documentCompletions(document, position));
+		items.push(...this.importedCompletions(model, document, position));
 		items.push(...this.callbackCompletions(model, document, position));
+
+		return items;
+	}
+
+	/**
+	 * Names an `import` in this document actually binds — a module under its
+	 * own name or an `as` alias, a member pulled out with `from`, or a Lumen
+	 * class. These are the names that mean something here, as opposed to the
+	 * full standard library `globalCompletions` used to offer regardless of
+	 * whether anything imported it.
+	 *
+	 * @param {Api} model
+	 * @param {vscode.TextDocument} document
+	 * @param {vscode.Position} position
+	 * @returns {vscode.CompletionItem[]}
+	 */
+	importedCompletions(model, document, position) {
+		const imports = analyzer.resolveImports(model, document.getText());
+		const word = document.getWordRangeAtPosition(position);
+		const typing = word ? document.getText(word) : '';
+		/** @type {vscode.CompletionItem[]} */
+		const items = [];
+
+		for (const [name, binding] of imports) {
+			if (name === typing) {
+				continue;
+			}
+
+			if (binding.kind === 'module') {
+				const module = model.moduleByName.get(binding.module);
+				const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Module);
+
+				item.detail = (binding.scheme === 'lumen' ? 'Lumen' : 'Ghost') + ' module';
+
+				if (module) {
+					item.documentation = new vscode.MarkdownString(module.doc);
+				}
+
+				item.sortText = '1' + name;
+				items.push(item);
+			} else if (binding.kind === 'member') {
+				const module = model.moduleByName.get(binding.module);
+				const member = module && module.members.find((candidate) => candidate.name === binding.member);
+
+				if (member) {
+					const item = this.memberItem(member, binding.module, binding.scheme);
+
+					item.label = name;
+					item.filterText = name;
+
+					if (name !== member.name && member.kind === 'method') {
+						item.insertText = new vscode.SnippetString(name + (endsWithNoArguments(member) ? '()' : '($0)'));
+					} else if (name !== member.name) {
+						item.insertText = name;
+					}
+
+					item.sortText = '1' + name;
+					items.push(item);
+				}
+			} else if (binding.kind === 'class') {
+				const type = model.typeByName.get(/** @type {string} */ (binding.type));
+
+				if (type) {
+					const item = this.classItem(type);
+
+					item.label = name;
+					item.filterText = name;
+
+					if (name !== type.name) {
+						item.insertText = new vscode.SnippetString(name + '($0)');
+					}
+
+					item.sortText = '1' + name;
+					items.push(item);
+				}
+			}
+		}
 
 		return items;
 	}

--- a/src/providers/hover.js
+++ b/src/providers/hover.js
@@ -12,8 +12,9 @@ const { documentationFor } = require('./completion');
  * Hover documentation.
  *
  * The word under the cursor is looked up the same way completion resolves a
- * receiver, so `sheet.newAnimation` documents the Spritesheet method even
- * though `sheet` is an ordinary untyped variable.
+ * receiver, so `walk.setSpeed` documents the Animation method even though
+ * `walk` is an ordinary untyped variable, once `walk = new Animation(...)`
+ * appears earlier in the document.
  */
 class GhostHoverProvider {
 	/**
@@ -69,7 +70,8 @@ class GhostHoverProvider {
 
 		if (chain) {
 			const known = analyzer.inferTypes(model, document.getText());
-			const resolved = analyzer.resolveChain(model, chain, known);
+			const imports = analyzer.resolveImports(model, document.getText());
+			const resolved = analyzer.resolveChain(model, chain, known, imports);
 
 			if (resolved && resolved.kind === 'module') {
 				const found = api.findModuleMember(model, resolved.name, word);
@@ -124,7 +126,13 @@ class GhostHoverProvider {
 	 * @returns {vscode.Hover | undefined}
 	 */
 	plainHover(model, document, range, word, position) {
-		const module = model.moduleByName.get(word);
+		const text = document.getText();
+		const imports = analyzer.resolveImports(model, text);
+
+		// `console` needs no import; every other module has to be the name (or
+		// alias) something in the document actually imported it under.
+		const moduleName = analyzer.resolveModuleName(model, word, imports);
+		const module = moduleName && model.moduleByName.get(moduleName);
 
 		if (module) {
 			const markdown = new vscode.MarkdownString();
@@ -133,6 +141,35 @@ class GhostHoverProvider {
 			markdown.appendMarkdown(module.doc + '\n\n_' + (module.source === 'lumen' ? 'Lumen' : 'Ghost') + ' module_');
 
 			return new vscode.Hover(markdown, range);
+		}
+
+		const binding = imports.get(word);
+
+		// A name pulled in with `import { sqrt } from "ghost:math"` reads, on
+		// its own, exactly like the module method it is.
+		if (binding && binding.kind === 'member') {
+			const owner = model.moduleByName.get(binding.module);
+			const member = owner && owner.members.find((candidate) => candidate.name === binding.member);
+
+			if (member) {
+				return this.render(range, member.signature || binding.module + '.' + member.name, member, member.source || binding.scheme);
+			}
+		}
+
+		// A Lumen class pulled in with `import { Spritesheet } from
+		// "lumen:image"` — worth documenting on its own name, not only once it
+		// is behind `new`.
+		if (binding && binding.kind === 'class') {
+			const type = model.typeByName.get(/** @type {string} */ (binding.type));
+
+			if (type) {
+				const markdown = new vscode.MarkdownString();
+
+				markdown.appendCodeblock(word, 'ghost');
+				markdown.appendMarkdown(type.doc);
+
+				return new vscode.Hover(markdown, range);
+			}
 		}
 
 		const fn = api.findFunction(model, word);
@@ -148,7 +185,7 @@ class GhostHoverProvider {
 			return this.render(range, callback.signature, callback, callback.source);
 		}
 
-		const variableType = analyzer.inferTypes(model, document.getText()).get(word);
+		const variableType = analyzer.inferTypes(model, text).get(word);
 
 		if (variableType) {
 			const type = model.typeByName.get(variableType);

--- a/src/providers/semanticTokens.js
+++ b/src/providers/semanticTokens.js
@@ -20,8 +20,13 @@ const LEGEND = new vscode.SemanticTokensLegend(
  * regular expression can answer, so it is answered here, where the whole
  * document is in hand:
  *
- *   - A name the document assigns to is that assignment, not a module. Writing
- *     `image = 3` shadows the module, and the highlighting follows.
+ *   - Only `console` is reachable without an `import`. Everything else — a
+ *     module accessed by name, an alias, or a name pulled in with `from` — is
+ *     highlighted only where the document actually imports it, resolved
+ *     through `analyzer.resolveImports` the same way completion and hover are.
+ *   - A name the document assigns to is that assignment, not an import. Writing
+ *     `image = 3` after `import "lumen:image"` shadows the import, and the
+ *     highlighting follows.
  *   - Whether Lumen's surface exists at all follows `ghost.lumen.enable`, which
  *     a grammar cannot be switched off by.
  *   - Members are resolved against the module they are actually reached
@@ -45,6 +50,7 @@ class GhostSemanticTokensProvider {
 		const stripped = analyzer.strip(text);
 		const builder = new vscode.SemanticTokensBuilder(LEGEND);
 		const shadowed = shadowedNames(text);
+		const imports = analyzer.resolveImports(model, text);
 
 		/** @type {(offset: number, length: number, type: string, modifiers: string[]) => void} */
 		const push = (offset, length, type, modifiers) => {
@@ -59,14 +65,22 @@ class GhostSemanticTokensProvider {
 			builder.push(start.line, start.character, length, LEGEND.tokenTypes.indexOf(type), encode(modifiers));
 		};
 
-		// Module accesses: `module.member`.
+		// Module accesses: `module.member`, resolved through whatever the
+		// leading name is actually bound to — its own name, needing no import
+		// (`console`), or an import binding, aliased or not.
 		const access = /\b([A-Za-z_]\w*)\s*\.\s*([A-Za-z_]\w*)/g;
 		let match;
 
 		while ((match = access.exec(stripped)) !== null) {
-			const [, moduleName, memberName] = match;
+			const [, boundName, memberName] = match;
 
-			if (shadowed.has(moduleName) || !model.moduleByName.has(moduleName)) {
+			if (shadowed.has(boundName)) {
+				continue;
+			}
+
+			const moduleName = analyzer.resolveModuleName(model, boundName, imports);
+
+			if (!moduleName) {
 				continue;
 			}
 
@@ -78,7 +92,7 @@ class GhostSemanticTokensProvider {
 				continue;
 			}
 
-			push(match.index, moduleName.length, 'namespace', ['defaultLibrary']);
+			push(match.index, boundName.length, 'namespace', ['defaultLibrary']);
 
 			const found = api.findModuleMember(model, moduleName, memberName);
 
@@ -94,13 +108,25 @@ class GhostSemanticTokensProvider {
 			}
 		}
 
-		// Global functions, only where called and not shadowed.
+		// Calls to a global function (`type`) or to a name pulled in directly
+		// with `import { sqrt } from "ghost:math"` — callable under its own
+		// name, without the module prefix.
 		const globals = /\b([A-Za-z_]\w*)\s*\(/g;
 
 		while ((match = globals.exec(stripped)) !== null) {
 			const name = match[1];
 
-			if (shadowed.has(name) || !api.findFunction(model, name)) {
+			if (shadowed.has(name)) {
+				continue;
+			}
+
+			const fn = api.findFunction(model, name);
+			const binding = imports.get(name);
+			const importedOwner = binding && binding.kind === 'member' ? model.moduleByName.get(binding.module) : undefined;
+			const importedMethod = importedOwner &&
+				importedOwner.members.some((member) => member.name === binding.member && member.kind === 'method');
+
+			if (!fn && !importedMethod) {
 				continue;
 			}
 
@@ -113,7 +139,8 @@ class GhostSemanticTokensProvider {
 
 		// Lumen's engine callbacks, where they are declared. The engine finds
 		// these by name, so marking them makes a misspelt one visible — it would
-		// otherwise simply never be called, with nothing to report.
+		// otherwise simply never be called, with nothing to report. Plain
+		// top-level declarations, unaffected by the import system.
 		const declarations = /\bfunction\s+([A-Za-z_]\w*)\s*\(/g;
 
 		while ((match = declarations.exec(stripped)) !== null) {
@@ -131,8 +158,8 @@ class GhostSemanticTokensProvider {
 }
 
 /**
- * Names the document binds itself. A module name is only a module until
- * something in the file assigns to it.
+ * Names the document assigns to itself. An import binding is only good until
+ * something in the file reassigns the same name.
  *
  * @param {string} text
  * @returns {Set<string>}
@@ -153,20 +180,6 @@ function shadowedNames(text) {
 	};
 
 	collect(analyzer.parseSymbols(text));
-
-	// Imported names bind too, and are not assignments.
-	const imported = /\bimport\s+([^\n]*?)\bfrom\b/g;
-	let match;
-
-	while ((match = imported.exec(analyzer.strip(text))) !== null) {
-		for (const name of match[1].split(',')) {
-			const cleaned = name.trim().split(/\s+as\s+/).pop();
-
-			if (cleaned && /^[A-Za-z_]\w*$/.test(cleaned)) {
-				names.add(cleaned);
-			}
-		}
-	}
 
 	return names;
 }

--- a/src/providers/signature.js
+++ b/src/providers/signature.js
@@ -72,13 +72,15 @@ class GhostSignatureHelpProvider {
 	 */
 	resolve(model, document, upToName, name, nameStart) {
 		const before = upToName.slice(0, nameStart);
+		const text = document.getText();
 
 		if (/\.\s*$/.test(before)) {
 			const chain = analyzer.receiverChain(before, before.lastIndexOf('.'));
 
 			if (chain) {
-				const known = analyzer.inferTypes(model, document.getText());
-				const resolved = analyzer.resolveChain(model, chain, known);
+				const known = analyzer.inferTypes(model, text);
+				const imports = analyzer.resolveImports(model, text);
+				const resolved = analyzer.resolveChain(model, chain, known, imports);
 
 				if (resolved && resolved.kind === 'module') {
 					const found = api.findModuleMember(model, resolved.name, name);
@@ -113,6 +115,27 @@ class GhostSignatureHelpProvider {
 
 		if (fn) {
 			return { signature: fn.signature, doc: fn.doc };
+		}
+
+		// A bare call can also be a name pulled in with `import { sqrt } from
+		// "ghost:math"` — reachable, and callable, without the module prefix.
+		const binding = analyzer.resolveImports(model, text).get(name);
+
+		if (binding && binding.kind === 'member') {
+			const owner = model.moduleByName.get(binding.module);
+			const member = owner && owner.members.find((candidate) => candidate.name === binding.member);
+
+			if (member && member.signature) {
+				return { signature: member.signature, doc: member.doc };
+			}
+		}
+
+		if (binding && binding.kind === 'class') {
+			const type = model.typeByName.get(/** @type {string} */ (binding.type));
+
+			if (type) {
+				return { signature: 'new ' + type.name + '(...)', doc: type.doc };
+			}
 		}
 
 		return undefined;

--- a/test/run.js
+++ b/test/run.js
@@ -14,6 +14,7 @@ const { makeDoc } = require('./document-stub');
 const SRC = path.join(__dirname, '..', 'src');
 
 const apiMod = require(SRC + '/api');
+const analyzer = require(SRC + '/analyzer');
 const { GhostCompletionProvider } = require(SRC + '/providers/completion');
 const { GhostHoverProvider } = require(SRC + '/providers/hover');
 const { GhostSignatureHelpProvider } = require(SRC + '/providers/signature');
@@ -29,10 +30,18 @@ const check = (name, cond, extra) => {
 const withLumen = () => apiMod.build(true);
 const noLumen = () => apiMod.build(false);
 
-const GAME = `import Player from 'player'
+// Every module except `console` needs an `import` before it can be used at
+// all — Ghost's own standard library and Lumen's modules alike. This fixture
+// exercises the bare form, the combined `name, { ... }` form, and a `.ghost`
+// file import (which the analyzer cannot resolve, and isn't meant to).
+const GAME = `import "lumen:canvas"
+import "lumen:color"
+import "lumen:filesystem"
+import image, { Spritesheet, Animation } from "lumen:image"
+import Player from 'player'
 
-sheet = image.newSpritesheet('chars.png', 16)
-walk = sheet.newAnimation([4, 5, 6, 7], 0.16)
+sheet = new Spritesheet('chars.png', 16)
+walk = new Animation(sheet, [4, 5, 6, 7], 0.16)
 
 class Hero extends Actor {
     function constructor(name) {
@@ -41,7 +50,7 @@ class Hero extends Actor {
     }
 
     speak() {
-        print("hi")
+        console.log("hi")
     }
 }
 
@@ -59,17 +68,56 @@ function draw() {
 }
 `;
 
+console.log('\n== import resolution ==');
+{
+  const model = withLumen();
+
+  const cases = [
+    ['import "ghost:math"', { math: 'module' }],
+    ['import "ghost:math" as m', { m: 'module' }],
+    ['import { pi, sqrt } from "ghost:math"', { pi: 'member', sqrt: 'member' }],
+    ['import pi, sqrt from "ghost:math"', { pi: 'member', sqrt: 'member' }],
+    ['import pi as p from "ghost:math"', { p: 'member' }],
+    ['import math, { pi } from "ghost:math"', { math: 'module', pi: 'member' }],
+    ['import image, { Spritesheet } from "lumen:image"', { image: 'module', Spritesheet: 'class' }],
+    ['import { Spritesheet, Animation } from "lumen:image"', { Spritesheet: 'class', Animation: 'class' }],
+    ['import * from "ghost:random"', { random: 'member', seed: 'member', currentSeed: 'member' }],
+    ['import "helpers"', {}],
+    ['import "helpers" as h', {}],
+    ['import Player from "player"', {}]
+  ];
+
+  for (const [source, expected] of cases) {
+    const bindings = analyzer.resolveImports(model, source);
+
+    for (const [name, kind] of Object.entries(expected)) {
+      const got = bindings.get(name);
+      check(source + ' binds ' + name, Boolean(got) && got.kind === kind, JSON.stringify(got));
+    }
+
+    check(source + ' binds exactly the expected names', bindings.size === Object.keys(expected).length, [...bindings.keys()].join(','));
+  }
+}
+
 console.log('\n== completion: module member ==');
 {
   const c = new GhostCompletionProvider(withLumen);
-  const doc = makeDoc('canvas.');
-  const items = c.provideCompletionItems(doc, new vscode.Position(0, 7));
+  const doc = makeDoc('import "lumen:canvas"\ncanvas.');
+  const items = c.provideCompletionItems(doc, new vscode.Position(1, 7));
   const names = items.map(i => i.label);
   check('offers canvas members', names.includes('filledRectangle') && names.includes('setColor'));
   check('includes canvas properties', names.includes('width'));
   check('excludes other modules\' members', !names.includes('setTitle'));
   const rect = items.find(i => i.label === 'filledRectangle');
   check('signature in detail', rect.detail === 'canvas.filledRectangle(x, y, w, h)', rect.detail);
+}
+
+console.log('\n== completion: member access requires import ==');
+{
+  const c = new GhostCompletionProvider(withLumen);
+  const items = c.provideCompletionItems(makeDoc('canvas.'), new vscode.Position(0, 7));
+  const names = items.map(i => i.label);
+  check('un-imported canvas offers no canvas members', !names.includes('filledRectangle'));
 }
 
 console.log('\n== completion: inferred receiver ==');
@@ -86,7 +134,7 @@ console.log('\n== completion: inferred receiver ==');
 console.log('\n== completion: this. inside class ==');
 {
   const c = new GhostCompletionProvider(withLumen);
-  const body = GAME.replace('        print("hi")', '        this.');
+  const body = GAME.replace('        console.log("hi")', '        this.');
   const doc = makeDoc(body);
   const lineNo = body.split('\n').findIndex(l => l.trim() === 'this.');
   const items = c.provideCompletionItems(doc, new vscode.Position(lineNo, body.split('\n')[lineNo].length));
@@ -113,30 +161,77 @@ console.log('\n== completion: globals + callbacks ==');
   const items = c.provideCompletionItems(doc, new vscode.Position(0, 2));
   const names = items.map(i => typeof i.label === 'string' ? i.label : i.label.label);
   check('offers keywords', names.includes('function') && names.includes('switch'));
-  check('offers modules', names.includes('canvas') && names.includes('math'));
-  check('offers globals', names.includes('print') && names.includes('type'));
+  check('offers the one global module', names.includes('console'));
+  check('does not offer modules that need an import', !names.includes('canvas') && !names.includes('math'));
+  check('offers the one global function', names.includes('type'));
   check('offers lumen callbacks', names.includes('update') && names.includes('mousepressed'));
   const upd = items.find(i => (typeof i.label === 'object' ? i.label.label : i.label) === 'update' && i.kind === vscode.CompletionItemKind.Event);
   check('callback inserts full body', upd && /function update\(dt\) \{/.test(upd.insertText.value), upd && upd.insertText.value);
 }
 
+console.log('\n== completion: names an import already bound ==');
+{
+  const c = new GhostCompletionProvider(withLumen);
+  const doc = makeDoc('import "ghost:math" as m\nimport { sqrt } from "ghost:math"\nx');
+  const items = c.provideCompletionItems(doc, new vscode.Position(2, 1));
+  const names = items.map(i => i.label);
+  check('offers the aliased module', names.includes('m'));
+  check('offers the named import as a callable', names.includes('sqrt'));
+  const sqrtItem = items.find(i => i.label === 'sqrt');
+  check('named import completion documents the real module', /math\.sqrt/.test(sqrtItem.detail), sqrtItem.detail);
+}
+
+console.log('\n== completion: import statement ==');
+{
+  const c = new GhostCompletionProvider(withLumen);
+
+  const doc1 = makeDoc('import ca');
+  const items1 = c.provideCompletionItems(doc1, new vscode.Position(0, 9));
+  const names1 = items1.map(i => i.label);
+  check('offers canvas as an importable module', names1.includes('canvas'));
+  const canvasItem = items1.find(i => i.label === 'canvas');
+  check('inserts the full scheme path', canvasItem.insertText.value === '"lumen:canvas"', canvasItem.insertText.value);
+  check('does not offer the global console module to import', !names1.includes('console'));
+
+  const doc2 = makeDoc('import "ghost:m');
+  const items2 = c.provideCompletionItems(doc2, new vscode.Position(0, 15));
+  const names2 = items2.map(i => i.label);
+  check('offers math inside an open ghost: string', names2.includes('math'));
+  check('does not offer lumen modules for the ghost scheme', !names2.includes('canvas'));
+
+  const doc3 = makeDoc('import { pi,  } from "ghost:math"');
+  const items3 = c.provideCompletionItems(doc3, new vscode.Position(0, 13));
+  const names3 = items3.map(i => i.label);
+  check('offers other math members inside the braces', names3.includes('sqrt'));
+  check('does not re-offer a name already in the list', !names3.includes('pi'));
+
+  const doc4 = makeDoc('import { Spritesheet,  } from "lumen:image"');
+  const items4 = c.provideCompletionItems(doc4, new vscode.Position(0, 22));
+  const names4 = items4.map(i => i.label);
+  check('offers a sibling class inside the braces', names4.includes('Animation'));
+}
+
 console.log('\n== completion: lumen disabled ==');
 {
   const c = new GhostCompletionProvider(noLumen);
-  const doc = makeDoc('x');
-  const items = c.provideCompletionItems(doc, new vscode.Position(0, 1));
-  const names = items.map(i => typeof i.label === 'string' ? i.label : i.label.label);
-  check('no lumen modules', !names.includes('canvas') && !names.includes('window'));
-  check('ghost modules remain', names.includes('math') && names.includes('console'));
-  check('no lumen callbacks', !names.includes('mousepressed'));
 
-  const mathItems = c.provideCompletionItems(makeDoc('math.'), new vscode.Position(0, 5)).map(i => i.label);
-  check('math has no lumen extensions', !mathItems.includes('clamp') && !mathItems.includes('lerp'));
-  check('math keeps ghost methods', mathItems.includes('abs') && mathItems.includes('pi'));
+  const items = c.provideCompletionItems(makeDoc('import ca'), new vscode.Position(0, 9));
+  const names = items.map(i => i.label);
+  check('no lumen modules to import', !names.includes('canvas') && !names.includes('window'));
+
+  const ghostItems = c.provideCompletionItems(makeDoc('import ma'), new vscode.Position(0, 9)).map(i => i.label);
+  check('ghost modules remain importable', ghostItems.includes('math'));
+
+  const upNames = c.provideCompletionItems(makeDoc('x'), new vscode.Position(0, 1))
+    .map(i => typeof i.label === 'string' ? i.label : i.label.label);
+  check('no lumen callbacks', !upNames.includes('mousepressed'));
+
+  const mathItems = c.provideCompletionItems(makeDoc('import "ghost:math"\nmath.'), new vscode.Position(1, 5)).map(i => i.label);
+  check('math keeps its full native surface without lumen', mathItems.includes('abs') && mathItems.includes('clamp') && mathItems.includes('sqrt'));
 
   const withL = new GhostCompletionProvider(withLumen);
-  const mathL = withL.provideCompletionItems(makeDoc('math.'), new vscode.Position(0, 5)).map(i => i.label);
-  check('math gains lumen extensions when on', mathL.includes('clamp') && mathL.includes('abs'));
+  const mathItemsL = withL.provideCompletionItems(makeDoc('import "ghost:math"\nmath.'), new vscode.Position(1, 5)).map(i => i.label);
+  check('math is the same module whether lumen is on or off', mathItemsL.length === mathItems.length, mathItemsL.length + ' vs ' + mathItems.length);
 }
 
 console.log('\n== hover ==');
@@ -147,35 +242,59 @@ console.log('\n== hover ==');
 
   const ln = lines.findIndex(l => l.includes('canvas.setColor'));
   const hv = h.provideHover(doc, new vscode.Position(ln, lines[ln].indexOf('setColor') + 2));
-  check('module method hover', hv && /canvas\.setColor\(color\)/.test(hv.contents.value), hv && hv.contents.value.slice(0,80));
+  check('module method hover', hv && /canvas\.setColor\(color\)/.test(hv.contents.value), hv && hv.contents.value.slice(0, 80));
 
   const ln2 = lines.findIndex(l => l.includes('walk.draw'));
   const hv2 = h.provideHover(doc, new vscode.Position(ln2, lines[ln2].indexOf('draw') + 1));
-  check('inferred receiver hover', hv2 && /Animation\.draw/.test(hv2.contents.value), hv2 && hv2.contents.value.slice(0,80));
+  check('inferred receiver hover', hv2 && /Animation\.draw/.test(hv2.contents.value), hv2 && hv2.contents.value.slice(0, 80));
 
-  const ln3 = lines.findIndex(l => l.includes('print("hi")'));
-  const hv3 = h.provideHover(doc, new vscode.Position(ln3, lines[ln3].indexOf('print') + 1));
-  check('global function hover', hv3 && /print\(value/.test(hv3.contents.value));
+  const ln3 = lines.findIndex(l => l.includes('console.log("hi")'));
+  const hv3 = h.provideHover(doc, new vscode.Position(ln3, lines[ln3].indexOf('log') + 1));
+  check('global console module method hover', hv3 && /console\.log\(value/.test(hv3.contents.value));
 
-  const hv4 = h.provideHover(makeDoc('canvas.scale(2)'), new vscode.Position(0, 2));
+  const hv4 = h.provideHover(makeDoc('import "lumen:canvas"\ncanvas.scale(2)'), new vscode.Position(1, 2));
   check('module name hover', hv4 && /transform stack/.test(hv4.contents.value));
 
   const hv5 = h.provideHover(makeDoc('x = "a comment print here"'), new vscode.Position(0, 15));
   check('no hover inside a string', !hv5);
+
+  const hv6 = h.provideHover(makeDoc('canvas.scale(2)'), new vscode.Position(0, 2));
+  check('un-imported module gives no hover', !hv6);
+
+  const hv7 = h.provideHover(makeDoc('import "ghost:math" as m\nm.pi'), new vscode.Position(1, 0));
+  check('aliased module hover resolves the real module', hv7 && /trigonometry/.test(hv7.contents.value), hv7 && hv7.contents.value.slice(0, 140));
+
+  const hv8 = h.provideHover(makeDoc('import { sqrt } from "ghost:math"\nsqrt(4)'), new vscode.Position(1, 1));
+  check('imported bare function hover', hv8 && /math\.sqrt/.test(hv8.contents.value), hv8 && hv8.contents.value.slice(0, 80));
+
+  const hv9 = h.provideHover(makeDoc('import { Spritesheet } from "lumen:image"\nSpritesheet'), new vscode.Position(1, 3));
+  check('imported bare class hover', hv9 && /grid of equally sized frames/.test(hv9.contents.value), hv9 && hv9.contents.value.slice(0, 80));
+
+  const hv10 = h.provideHover(makeDoc('type(3)'), new vscode.Position(0, 1));
+  check('global function hover', hv10 && /type\(value\)/.test(hv10.contents.value));
 }
 
 console.log('\n== signature help ==');
 {
   const s = new GhostSignatureHelpProvider(withLumen);
-  const doc = makeDoc('canvas.filledRectangle(1, 2, ');
-  const help = s.provideSignatureHelp(doc, new vscode.Position(0, 29));
+
+  const doc = makeDoc('import "lumen:canvas"\ncanvas.filledRectangle(1, 2, ');
+  const help = s.provideSignatureHelp(doc, new vscode.Position(1, 29));
   check('resolves signature', help && help.signatures[0].label === 'canvas.filledRectangle(x, y, w, h)', help && help.signatures[0].label);
   check('tracks active parameter', help && help.activeParameter === 2, help && String(help.activeParameter));
-  check('splits params', help && help.signatures[0].parameters.map(p=>p.label).join('|') === 'x|y|w|h');
+  check('splits params', help && help.signatures[0].parameters.map(p => p.label).join('|') === 'x|y|w|h');
 
   const d2 = makeDoc(GAME + '\nwalk.draw(1, 2, 3, ');
   const h2 = s.provideSignatureHelp(d2, new vscode.Position(GAME.split('\n').length, 19));
-  check('optional tail expanded', h2 && h2.signatures[0].parameters.map(p=>p.label).join('|') === 'x|y|rotation|sx|sy|ox|oy', h2 && h2.signatures[0].parameters.map(p=>p.label).join('|'));
+  check('optional tail expanded', h2 && h2.signatures[0].parameters.map(p => p.label).join('|') === 'x|y|rotation|sx|sy|ox|oy', h2 && h2.signatures[0].parameters.map(p => p.label).join('|'));
+
+  const d3 = makeDoc('import { sqrt } from "ghost:math"\nsqrt(');
+  const h3 = s.provideSignatureHelp(d3, new vscode.Position(1, 5));
+  check('imported bare function signature help', h3 && h3.signatures[0].label === 'math.sqrt(n)', h3 && h3.signatures[0].label);
+
+  const d4 = makeDoc('canvas.filledRectangle(1, 2, ');
+  const h4 = s.provideSignatureHelp(d4, new vscode.Position(0, 29));
+  check('no signature help for an un-imported module', !h4);
 }
 
 console.log('\n== document symbols ==');
@@ -187,7 +306,7 @@ console.log('\n== document symbols ==');
   check('records superclass', hero && hero.detail === 'extends Actor', hero && hero.detail);
   check('nests methods', hero && hero.children.some(c => c.name === 'speak'));
   check('nests constructor fields', hero && hero.children.some(c => c.children.some(g => g.name === 'hp')));
-  check('finds top-level functions', ['load','update','draw'].every(n => syms.some(s => s.name === n)));
+  check('finds top-level functions', ['load', 'update', 'draw'].every(n => syms.some(s => s.name === n)));
   const inRange = (s) => s.range.contains(s.selectionRange) && s.children.every(inRange);
   check('selection ranges nested in full ranges', syms.every(inRange));
 }
@@ -200,10 +319,15 @@ console.log('\n== semantic tokens ==');
   check('marks module namespaces', kinds.includes('namespace'));
   check('marks module methods', kinds.includes('method'));
   check('marks lumen callbacks', toks.some(t => t.type === 'event'));
-  check('marks builtin functions', toks.some(t => t.type === 'function'));
 
-  const shadow = st.provideDocumentSemanticTokens(makeDoc('image = 3\nimage.foo()\n')).tokens;
-  check('a shadowed module is not a module', shadow.length === 0, JSON.stringify(shadow));
+  const noImport = st.provideDocumentSemanticTokens(makeDoc('canvas.foo()\n')).tokens;
+  check('an un-imported module is not highlighted', noImport.length === 0, JSON.stringify(noImport));
+
+  const shadow = st.provideDocumentSemanticTokens(makeDoc('import "lumen:image"\nimage = 3\nimage.foo()\n')).tokens;
+  check('a shadowed import is not a module', shadow.length === 0, JSON.stringify(shadow));
+
+  const bareFn = st.provideDocumentSemanticTokens(makeDoc('import { sqrt } from "ghost:math"\nsqrt(4)\n')).tokens;
+  check('marks an imported bare function call', bareFn.some(t => t.type === 'function'), JSON.stringify(bareFn));
 
   const off = new GhostSemanticTokensProvider(noLumen).provideDocumentSemanticTokens(makeDoc(GAME)).tokens;
   check('no lumen tokens when disabled', !off.some(t => t.type === 'event'));


### PR DESCRIPTION
## Summary

Both `ghost-language/ghost` and `ghost-language/lumen` have moved substantially since this extension was last synced — most importantly, Ghost adopted an import-based module system (`import ... from "ghost:name"` / `"lumen:name"`) where only `console` and the global `type()` function remain reachable without an import. This PR brings the extension's data and providers up to date with both codebases (checked out and read directly, not guessed).

- **`src/api/ghost.js`** re-transcribed against the current interpreter:
  - The old `io` module split into `file` and `path`; the old `time` module is gone, folded into `os.sleep` and a new `date` module (date-fns-style, UTC only).
  - `math` grew enormously: trigonometry, a full linear-algebra layer, statistics, and arithmetic exposed as callable methods (127 members total).
  - `List` gained `map`, `filter`, `reduce`, `sort`, `slice`, `concat`, `contains`, `reverse`, `unique`, `each`, and a new `shift()`. **`List.pop()` changed meaning** — it now pops from the end (mirroring `push`), and the old first-element behavior moved to `shift()`.
  - `Map` gained real methods (`get`, `set`, `has`, `keys`, `values`, `length`, `merge`) — previously undocumented as having none.
  - The global `print()` is gone entirely, replaced by `console.log`/`console.write`.
- **`src/api/lumen.js`** re-transcribed against the current engine:
  - Lumen no longer extends Ghost's `math` module at all — everything it used to bolt on there now ships natively in `ghost:math`.
  - `Image`, `Spritesheet`, `Animation`, `Source`, `Font`, `Target` and `Quad` are now `new`-able classes imported from their owning module (`lumen:image`, `lumen:audio`, `lumen:canvas`, `lumen:font`), replacing factory methods like the old `image.newSpritesheet()`/`canvas.newQuad()`.
- **`src/analyzer.js`** gained real import-statement parsing (`resolveImports`) supporting the bare, aliased, named (braced/unbraced), wildcard, and combined (`import name, { a, b } from "scheme:module"`) forms, plus `new Type(...)` assignment inference. All receiver/module resolution across the providers now goes through this instead of assuming every module name is globally available.
- **Completion, hover, signature help, and semantic highlighting** are now import-aware throughout: a module, alias, or named import only resolves (and only highlights) where the document actually imports it. Completion also now completes the `import` statement itself — module names after `import `, inside an open `"ghost:`/`"lumen:` string, and a module's members/classes inside `{ }` once the line names it via `from`.
- Extensive updates to `README.md`, `CHANGELOG.md`, and `test/run.js` (now 123 checks, including a dedicated import-resolution suite) to match.

## Test plan

- [x] `npm test` — 123/123 passing
- [x] Manually verified the built API model against both source repos (module lists, method signatures, `List.pop()`/`shift()` semantics, `Map` methods, Lumen's class-vs-module split) via `node -e` smoke checks
- [ ] Manual smoke test in an Extension Development Host (not done in this sandboxed session — no VS Code UI available)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FU5AAEVRUPHaUszGq9CnTs)_