### PR TITLE
Add CHANGELOG section for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2026-08-24
 ### Changed
 - Rewritten for Ghost's and Lumen's move to an import-based module system: only `console` and the
   global `type()` function are reachable without an `import` now, so completion, hover, signature


### PR DESCRIPTION
## Summary
- `package.json` was already bumped to `0.2.0`, but the changes were still sitting under `## [Unreleased]` in `CHANGELOG.md`, so `scripts/release-notes.js` (and the `release tooling` test in `test/run.js`) couldn't find a `## [0.2.0]` section
- This is what was failing the tag/release workflow with `FAIL CHANGELOG has notes for version 0.2.0` / `FAIL notes stop at the next version`
- Renamed the section to `## [0.2.0] - 2026-08-24` and left a fresh empty `## [Unreleased]` above it

## Test plan
- [x] `node test/run.js` — all 123 checks pass, including the `release tooling` suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDfvru9ac4Xp5mRVEmwW2S)_